### PR TITLE
Fixing undefined logger variable

### DIFF
--- a/lib/datadog/lambda/trace/patch_http.rb
+++ b/lib/datadog/lambda/trace/patch_http.rb
@@ -30,7 +30,6 @@ module Datadog
     # NetExtensions contains patches which add tracing context to http calls
     module NetExtensions
       def request(req, body = nil, &block)
-        logger = Datadog::Utils.logger
         begin
           context = Datadog::Trace.current_trace_context(
             Datadog::Trace.trace_context
@@ -39,7 +38,7 @@ module Datadog
           req = add_ctx_to_req(req, context)
         rescue StandardError => e
           trace = e.backtrace.join("\n ")
-          logger.debug(
+          Datadog::Utils.logger.debug(
             "couldn't add tracing context #{context} to request #{e}:\n#{trace}"
           )
         end
@@ -53,7 +52,7 @@ module Datadog
           context[:sample_mode]
         req[Datadog::Trace::DD_PARENT_ID_HEADER.to_sym] = context[:parent_id]
         req[Datadog::Trace::DD_TRACE_ID_HEADER.to_sym] = context[:trace_id]
-        logger.debug("added context #{context} to request")
+        Datadog::Utils.logger.debug("added context #{context} to request")
         req
       end
     end

--- a/lib/datadog/lambda/trace/patch_http.rb
+++ b/lib/datadog/lambda/trace/patch_http.rb
@@ -58,3 +58,4 @@ module Datadog
     end
   end
 end
+


### PR DESCRIPTION
### What does this PR do?

The local variable `logger` was not defined in the https://github.com/DataDog/datadog-lambda-rb/blob/master/lib/datadog/lambda/trace/patch_http.rb#L56, leading to exception raised and all sorts of funky behaviors afterwards.

### Motivation

2 days of debugging our service tracing problems.

### Testing Guidelines

None

### Additional Notes

No

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
