### PR TITLE
Add PR size checking

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -1,0 +1,32 @@
+name: check-size
+
+on: pull_request
+
+jobs:
+  check-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node 14.15
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.15
+
+      - name: Cache Node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Build Layers
+        run: ./scripts/build_layers.sh
+
+      - name: Check Size
+        run: ./scripts/check_layer_size.sh

--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+# Compares layer size to threshold, and fails if below that threshold
+
+# 5 mb size limit
+MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 8 \* 1024) 
+MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 14 \* 1024) 
+
+
+LAYER_FILES_PREFIX="datadog-lambda_ruby"
+LAYER_DIR=".layers"
+VERSIONS=("2.5" "2.7")
+
+for version in "${VERSIONS[@]}"
+do
+    FILE=$LAYER_DIR/${LAYER_FILES_PREFIX}${version}.zip
+    FILE_SIZE=$(stat --printf="%s" $FILE)
+    FILE_SIZE_KB="$(( ${FILE_SIZE%% *} / 1024))"
+    echo "Layer file ${FILE} has zipped size ${FILE_SIZE_KB} kb"
+    if [ "$FILE_SIZE_KB" -gt "$MAX_LAYER_COMPRESSED_SIZE_KB" ]; then
+        echo "Zipped size exceeded limit $MAX_LAYER_COMPRESSED_SIZE_KB kb"
+        exit 1
+    fi
+    mkdir tmp
+    unzip -q $FILE -d tmp
+    UNZIPPED_FILE_SIZE=$(du -shb tmp/ | cut -f1)
+    UNZIPPED_FILE_SIZE_KB="$(( ${UNZIPPED_FILE_SIZE%% *} / 1024))"
+    rm -rf tmp
+    echo "Layer file ${FILE} has unzipped size ${UNZIPPED_FILE_SIZE_KB} kb"
+    if [ "$UNZIPPED_FILE_SIZE_KB" -gt "$MAX_LAYER_UNCOMPRESSED_SIZE_KB" ]; then
+        echo "Unzipped size exceeded limit $MAX_LAYER_UNCOMPRESSED_SIZE_KB kb"
+        exit 1
+    fi
+done

--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -9,7 +9,7 @@
 
 # 5 mb size limit
 MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 8 \* 1024) 
-MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 14 \* 1024) 
+MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 20 \* 1024) 
 
 
 LAYER_FILES_PREFIX="datadog-lambda_ruby"


### PR DESCRIPTION
### What does this PR do?

Adds a check to PRs that will reject if a layer size exceeds a certain threshold, (both compressed and uncompressed).

### Motivation

Prevent accidental layer sizing drift.

### Testing Guidelines


### Additional Notes


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
