### PR TITLE
Update listener.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2019 Datadog, Inc.
+

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -56,7 +56,7 @@ module Datadog
       private
 
       def get_option_tags(request_context:, cold_start:)
-        function_arn = request_context.invoked_function_arn.downcase
+        function_arn = request_context.invoked_function_arn.to_s.downcase
         tk = function_arn.split(':')
         function_arn = tk.length > 7 ? tk[0, 7].join(':') : function_arn
         function_version = tk.length > 7 ? tk[7] : '$LATEST'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add `:to_s` to extraction of Function ARN in case this value is `nil`

<!--- A brief description of the change being made with this pull request. --->

### Motivation

When invoking the function with SAM, `context.invoked_function_arn` can be `nil` which causes the existing code to error

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I tested this by manually creating a mock context object where `context.invoked_function_arn == ""` and saw that it worked

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
