### PR TITLE
[SLS-1260] Add functionname attribute to span metadata

### DIFF
--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -60,13 +60,15 @@ module Datadog
         tk = function_arn.split(':')
         function_arn = tk.length > 7 ? tk[0, 7].join(':') : function_arn
         function_version = tk.length > 7 ? tk[7] : '$LATEST'
+        function_name = request_context.function_name
         options = {
           tags: {
             cold_start: cold_start,
             function_arn: function_arn,
             function_version: function_version,
             request_id: request_context.aws_request_id,
-            resource_names: request_context.function_name
+            functionname: function_name.nil? || function_name.empty? ? nil : function_name.downcase,
+            resource_names: function_name
           }
         }
         options

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -78,10 +78,10 @@ describe Datadog::Lambda do
       expect(Datadog::Lambda.gen_enhanced_tags(ctxv)).to include(
         { account_id: '172597598159',
           cold_start: false,
-          functionname: 'ruby-test',
+          functionname: 'Ruby-test',
           memorysize: 128,
           region: 'us-east-1',
-          resource: 'ruby-test:1',
+          resource: 'Ruby-test:1',
           runtime: include('Ruby 2.') }
       )
     end
@@ -92,10 +92,10 @@ describe Datadog::Lambda do
       expect(Datadog::Lambda.gen_enhanced_tags(ctxa)).to include(
         { account_id: '172597598159',
           cold_start: false,
-          functionname: 'ruby-test',
+          functionname: 'Ruby-test',
           memorysize: 128,
           region: 'us-east-1',
-          resource: 'ruby-test:my-alias',
+          resource: 'Ruby-test:my-alias',
           executedversion: '1',
           runtime: include('Ruby 2.') }
       )

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -208,6 +208,7 @@ describe Datadog::Trace do
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:hello-dog-ruby-dev-hello',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: "hello-dog-ruby-dev-helloRuby#{RUBY_VERSION[0, 3].tr('.', '')}",
+          functionname: "hello-dog-ruby-dev-helloRuby#{RUBY_VERSION[0, 3].tr('.', '')}".downcase,
           function_version: '$LATEST'
         }
       )
@@ -229,7 +230,8 @@ describe Datadog::Trace do
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:ruby-test',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
-          resource_names: 'ruby-test',
+          resource_names: 'Ruby-test',
+          functionname: 'ruby-test',
           function_version: '1'
         }
       )
@@ -251,7 +253,8 @@ describe Datadog::Trace do
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:ruby-test',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
-          resource_names: 'ruby-test',
+          resource_names: 'Ruby-test',
+          functionname: 'ruby-test',
           function_version: 'my-alias'
         }
       )

--- a/test/datadog/lambdacontextalias.rb
+++ b/test/datadog/lambdacontextalias.rb
@@ -5,7 +5,7 @@
 # Use dot-notation to access these properties
 class LambdaContextAlias
   def function_name
-    'ruby-test'
+    'Ruby-test'
   end
 
   def function_version

--- a/test/datadog/lambdacontextversion.rb
+++ b/test/datadog/lambdacontextversion.rb
@@ -5,7 +5,7 @@
 # Use dot-notation to access these properties
 class LambdaContextVersion
   def function_name
-    'ruby-test'
+    'Ruby-test'
   end
 
   def function_version


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Add the `functionname` attribute to the Lambda span metadata. 

### Motivation

<!--- What inspired you to submit this pull request? --->
Look at problem 2 here: https://docs.google.com/document/d/1Jd40XCKibvhVntIiT02xjaZZlq3P2ohRHZ8VnKtu46Q/edit#

### Testing Guidelines

<!--- How did you test this pull request? --->
Check the trace metadata tags to ensure the `functionname` attribute is present.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
