### PR TITLE
Update listener.rb #2

### DIFF
--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -102,7 +102,7 @@ module Datadog
     # @return [hash] a hash of the enhanced metrics tags
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def self.gen_enhanced_tags(context)
-      arn_parts = context.invoked_function_arn.split(':')
+      arn_parts = context.invoked_function_arn.to_s.split(':')
       # Check if we have an alias or version
       function_alias = arn_parts[7].nil? ? nil : arn_parts[7]
 


### PR DESCRIPTION
### What does this PR do?

Companion PR to #51 — Add `:to_s` to extraction of Function ARN in case this value is `nil`

### Motivation

When invoking the function with SAM locally, `context.invoked_function_arn` can be nil which causes an error

### Testing Guidelines

I tested this by making the change inside a SAM build directory and saw that the error no longer occurred.

### Additional Notes

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
