### PR TITLE
Add Ruby 3.1 support while keeping 2.7 compatibility

### DIFF
--- a/lib/datadog/lambda/trace/ddtrace.rb
+++ b/lib/datadog/lambda/trace/ddtrace.rb
@@ -33,7 +33,7 @@ module Datadog
           return block.call
         end
 
-        Datadog::Tracing.trace('aws.lambda', options) do |_span|
+        Datadog::Tracing.trace('aws.lambda', **options) do |_span|
           block.call
         end
       end


### PR DESCRIPTION
Ruby 3.1 requires hashes to be splatted to methods requiring keyword-arguments. Ruby 2.7 supports double-splatting in this way, so this commit changes the code to use this structure.

Context:

While https://github.com/DataDog/datadog-lambda-rb/issues/70 makes it clear that this gem doesn't have official Ruby 3.1 support on the roadmap yet, this two-character change make the gem work for people that want to run 3.1 at their own risk. (Notably when using more recent docker images)

Note that this doesn't change CI for datadog-lambda-rb to use 3.1, since that's a more significant task. The integration tests are tied to the officially-supported AWS ruby version, and at this point AWS only officially supports Ruby 2.7. So to get CI to test Ruby 3.1 we would need to transition the integration tests to docker-based lambdas.

It's worth noting that https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html does indicate that Ruby 3.2 will probably be coming "fairly soon", with Ruby 2.7 being provisionally marked as end-of-life at Nov 15, 2023

### What does this PR do?

Adjusts the code so that it can cleanly run on Ruby 2.7 AND Ruby 3.1

### Motivation

https://github.com/DataDog/datadog-lambda-rb/issues/70

### Testing Guidelines

I've run Ruby specs in 2.7 - the only supported version.

Additionally, we've been running this change in Ruby 3.1 in production for a few months now (via a monkey-patch)

### Additional Notes

I've not run the integration tests, because I think it's incredibly unlikely this would break anything - and I don't have the environment setup. Let me know if you think it _really_ needs this and I'll jump through all the hoops. It probably requires me to set up an entirely new AWS account for data-protection reasons :/

### Types of changes

- [x] Bug fix

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR's changes are covered by the automated tests
