### PR TITLE
feat: support custom metrics when using extension

### DIFF
--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-xray-sdk', '~> 0.11.3'
-  spec.add_dependency 'dogstatsd-ruby', '~> 5.6'
+  spec.add_dependency 'dogstatsd-ruby', '~> 5.0'
   # We don't add this as a direct dependency, because it has
   # native modules that are difficult to package for lambda
   spec.add_development_dependency 'ddtrace', '~>1.12.0'

--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-xray-sdk', '~> 0.11.3'
+  spec.add_dependency 'dogstatsd-ruby', '~> 5.6'
   # We don't add this as a direct dependency, because it has
   # native modules that are difficult to package for lambda
   spec.add_development_dependency 'ddtrace', '~>1.12.0'

--- a/integration_tests/snapshots/logs/async-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby27.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:15:22.398959 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby27.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:15:22.398959 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby32.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:43:02.272423 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby32.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:43:02.272423 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-error_ruby27.log
+++ b/integration_tests/snapshots/logs/http-error_ruby27.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:15:37.712534 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-error_ruby27.log
+++ b/integration_tests/snapshots/logs/http-error_ruby27.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:15:37.712534 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-error_ruby32.log
+++ b/integration_tests/snapshots/logs/http-error_ruby32.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:43:18.639912 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-error_ruby32.log
+++ b/integration_tests/snapshots/logs/http-error_ruby32.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:43:18.639912 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby27.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby27.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:15:32.550005 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby27.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby27.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:15:32.550005 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby32.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby32.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:43:13.107931 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby32.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby32.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:43:13.107931 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby27.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby27.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:15:43.576248 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby27.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby27.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:15:43.576248 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby32.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby32.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:43:24.777192 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby32.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby32.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:43:24.777192 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby27.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:15:27.441142 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby27.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:15:27.441142 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby32.log
@@ -1,4 +1,5 @@
 
+D, [2023-07-29T20:43:07.997595 #8] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby32.log
@@ -1,5 +1,5 @@
 
-D, [2023-07-29T20:43:07.997595 #8] DEBUG  -- : metrics are going to be handled by the forwarder
+D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -68,7 +68,7 @@ module Datadog
       ensure
         @listener.on_end
         @is_cold_start = false
-        @metrics_client.end
+        @metrics_client.close
       end
       res
     end

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -54,7 +54,7 @@ module Datadog
     # @param block [Proc] implementation of the handler function.
     def self.wrap(event, context, &block)
       Datadog::Utils.update_log_level
-      @trace_listener ||= initialize_listener
+      @listener ||= initialize_listener
       @listener.on_start(event: event)
       record_enhanced('invocations', context)
       begin

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -15,7 +15,6 @@ require 'datadog/lambda/utils/logger'
 require 'datadog/lambda/utils/extension'
 require 'datadog/lambda/trace/patch_http'
 require 'json'
-require 'time'
 require 'datadog/lambda/version'
 
 module Datadog

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -66,6 +66,7 @@ module Datadog
       ensure
         @listener.on_end
         @is_cold_start = false
+        Datadog::Metrics.end
       end
       res
     end
@@ -85,15 +86,7 @@ module Datadog
       raise 'name must be a string' unless name.is_a?(String)
       raise 'value must be a number' unless value.is_a?(Numeric)
 
-      time ||= Time.now
-      time_ms = time.to_f.to_i
-
-      tag_list = ["dd_lambda_layer:datadog-ruby#{dd_lambda_layer_tag}"]
-      tags.each do |tag|
-        tag_list.push("#{tag[0]}:#{tag[1]}")
-      end
-      metric = { e: time_ms, m: name, t: tag_list, v: value }
-      puts metric.to_json
+      Datadog::Metrics.distribution(name, value, time: time, **tags)
     end
 
     def self.dd_lambda_layer_tag

--- a/lib/datadog/lambda/metrics.rb
+++ b/lib/datadog/lambda/metrics.rb
@@ -30,7 +30,11 @@ module Datadog
 
         if Datadog::Utils.extension_running?
           Datadog::Utils.logger.debug 'sending metrics through extension'
-          @statsd.distribution(name, value, tags: tag_list)
+          begin
+            @statsd.distribution(name, value, tags: tag_list)
+          rescue StandardError => e
+            Datadog::Utils.logger.warning "error sending metric to the extension: #{e}"
+          end
         else
           Datadog::Utils.logger.debug 'metrics are going to be handled by the forwarder'
           time ||= Time.now

--- a/lib/datadog/lambda/metrics.rb
+++ b/lib/datadog/lambda/metrics.rb
@@ -29,8 +29,10 @@ module Datadog
         tag_list = get_tags(**tags)
 
         if Datadog::Utils.extension_running?
+          Datadog::Utils.logger.debug 'sending metrics through extension'
           @statsd.distribution(name, value, tags: tag_list)
         else
+          Datadog::Utils.logger.debug 'metrics are going to be handled by the forwarder'
           time ||= Time.now
           time_ms = time.to_f.to_i
 
@@ -52,7 +54,7 @@ module Datadog
         tag_list
       end
 
-      def initialize
+      private_class_method def initialize
         @statsd = Datadog::Statsd.new(URL, PORT, single_thread: true) if Datadog::Utils.extension_running?
       end
     end

--- a/lib/datadog/lambda/metrics.rb
+++ b/lib/datadog/lambda/metrics.rb
@@ -38,14 +38,14 @@ module Datadog
         else
           Datadog::Utils.logger.debug 'metrics are going to be handled by the forwarder'
           time ||= Time.now
-          time_ms = time.to_f.to_i
+          time_ms = time.to_i
 
           metric = { e: time_ms, m: name, t: tag_list, v: value }
           puts metric.to_json
         end
       end
 
-      def end
+      def close
         @statsd&.close
       end
 

--- a/lib/datadog/lambda/metrics.rb
+++ b/lib/datadog/lambda/metrics.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2023 Datadog, Inc.
+#
+
+require 'datadog/statsd'
+
+module Datadog
+  # Metrics module contains the singleton class Client to send custom
+  # metrics to Datadog.
+  module Metrics
+    URL = 'localhost'
+    PORT = '8125'
+    class << self
+      @instance = new
+
+      private_class_method :new
+
+      def self.distribution(name, value, time: nil, **tags)
+        tag_list = get_tags(**tags)
+
+        if Datadog::Utils.extension_running?
+          @instance.distribution(name, value, tags: tag_list)
+        else
+          time ||= Time.now
+          time_ms = time.to_f.to_i
+
+          metric = { e: time_ms, m: name, t: tag_list, v: value }
+          puts metric.to_json
+        end
+      end
+
+      def self.end
+        @instance&.close
+      end
+
+      def get_tags(**tags)
+        tag_list = ["dd_lambda_layer:datadog-ruby#{dd_lambda_layer_tag}"]
+        tags.each do |tag|
+          tag_list.push("#{tag[0]}:#{tag[1]}")
+        end
+
+        tag_list
+      end
+
+      def initialize
+        @instance = Datadog::Statsd.new(URL, PORT, single_thread: true) if Datadog::Utils.extension_running?
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/utils/extension.rb
+++ b/lib/datadog/lambda/utils/extension.rb
@@ -17,7 +17,17 @@ module Datadog
     EXTENSION_CHECK_URI = URI(AGENT_URL + HELLO_PATH).freeze
     EXTENSION_PATH = '/opt/extensions/datadog-agent'
 
+    @is_extension_running = nil
+
     def self.extension_running
+      return @is_extension_running unless @is_extension_running.nil?
+
+      @is_extension_running = ping_extension
+
+      @is_extension_running
+    end
+
+    def ping_extension
       return false unless File.exist?(EXTENSION_PATH)
 
       begin

--- a/lib/datadog/lambda/utils/extension.rb
+++ b/lib/datadog/lambda/utils/extension.rb
@@ -23,8 +23,6 @@ module Datadog
       return @is_extension_running unless @is_extension_running.nil?
 
       @is_extension_running = check_extension_running
-
-      @is_extension_running
     end
 
     def self.check_extension_running

--- a/lib/datadog/lambda/utils/extension.rb
+++ b/lib/datadog/lambda/utils/extension.rb
@@ -19,15 +19,15 @@ module Datadog
 
     @is_extension_running = nil
 
-    def self.extension_running
+    def self.extension_running?
       return @is_extension_running unless @is_extension_running.nil?
 
-      @is_extension_running = ping_extension
+      @is_extension_running = check_extension_running
 
       @is_extension_running
     end
 
-    def ping_extension
+    def self.check_extension_running
       return false unless File.exist?(EXTENSION_PATH)
 
       begin

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -206,6 +206,8 @@ for handler_name in "${LAMBDA_HANDLERS[@]}"; do
                 perl -p -e 's/(WARN |W, \[|Client:)( )?[a-zA-Z0-9\.\:\s\-\#]+/\1XXXX/g' |
                 # Information Log for Datadog Configuration
                 perl -p -e 's/(INFO |I, \[)( )?[a-zA-Z0-9\.\:\s\-\#]+/\1XXXX/g' |
+                # Debug Log for Datadog Configuration
+                perl -p -e 's/(D, \[)( )?[a-zA-Z0-9\.\:\s\-\#]+/\1XXXX/g' |
                 # Filter out INIT runtime logs
                 perl -p -e "s/INIT_START.*//g" |
                 sort

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -9,35 +9,64 @@ require_relative './lambdacontextalias'
 
 describe Datadog::Lambda do
   ctx = LambdaContext.new
-  dd_lambda_layer_tag = RUBY_VERSION[0, 3].tr('.', '')
+  let(:layer_tag) { RUBY_VERSION[0, 3].tr('.', '') }
+  let(:default_tags) { ["dd_lambda_layer:datadog-ruby#{layer_tag}"] }
+
   context 'enhanced tags' do
     it 'recognizes a cold start' do
       expect(Datadog::Lambda.gen_enhanced_tags(ctx)[:cold_start]).to eq(true)
     end
   end
-  context 'with a handler that raises an error' do
-    subject { Datadog::Lambda.wrap(event, context) { raise 'Error' } }
-    let(:event) { '1' }
-    let(:context) { ctx }
 
-    it 'should raise an error if the block raises an error' do
-      expect { subject }.to raise_error 'Error'
+  describe '#wrap' do
+    context 'with a handler that raises an error' do
+      subject { Datadog::Lambda.wrap(event, context) { raise 'Error' } }
+      let(:event) { '1' }
+      let(:context) { ctx }
+
+      it 'should raise an error if the block raises an error' do
+        expect { subject }.to raise_error 'Error'
+      end
+    end
+
+    context 'with a succesful handler' do
+      subject { Datadog::Lambda.wrap(event, context) { { result: 100 } } }
+      let(:event) { '1' }
+      let(:context) { ctx }
+
+      it 'should return the same value as returned by the block' do
+        expect(subject[:result]).to be 100
+      end
+    end
+
+    context 'with a handler that sends a custom metric' do
+      subject(:handler) do
+        Datadog::Lambda.wrap(event, context) do
+          Datadog::Lambda.metric('m1', 100, env: 'dev', region: 'nyc')
+          { result: 100 }
+        end
+      end
+      let(:event) { '1' }
+      let(:context) { ctx }
+      let(:metrics_client) { Datadog::Lambda.instance_variable_get(:@metrics_client) }
+
+      it 'should print metric and close the client' do
+        # Mock first distribution call which is for enhanced metrics
+        expect(metrics_client).to receive(:distribution)
+        # Mock second call which is our custom metric
+        expect(metrics_client).to receive(:distribution).with('m1', 100, time: nil, env: 'dev', region: 'nyc')
+        expect(metrics_client).to receive(:close)
+        expect(handler[:result]).to be 100
+      end
     end
   end
+
   context 'enhanced tags' do
     it 'recognizes an error as having warmed the environment' do
       expect(Datadog::Lambda.gen_enhanced_tags(ctx)[:cold_start]).to eq(false)
     end
   end
-  context 'with a succesful handler' do
-    subject { Datadog::Lambda.wrap(event, context) { { result: 100 } } }
-    let(:event) { '1' }
-    let(:context) { ctx }
 
-    it 'should return the same value as returned by the block' do
-      expect(subject[:result]).to be 100
-    end
-  end
   context 'trace_context' do
     it 'should return the last trace context' do
       event = {
@@ -64,10 +93,10 @@ describe Datadog::Lambda do
       expect(Datadog::Lambda.gen_enhanced_tags(ctx)).to include(
         account_id: '172597598159',
         cold_start: false,
-        functionname: "hello-dog-ruby-dev-helloRuby#{dd_lambda_layer_tag}",
+        functionname: "hello-dog-ruby-dev-helloRuby#{layer_tag}",
         memorysize: 128,
         region: 'us-east-1',
-        resource: "hello-dog-ruby-dev-helloRuby#{dd_lambda_layer_tag}"
+        resource: "hello-dog-ruby-dev-helloRuby#{layer_tag}"
       )
     end
   end
@@ -98,24 +127,55 @@ describe Datadog::Lambda do
       )
     end
   end
-  context 'metric' do
-    it 'prints a custom metric' do
-      now = Time.utc(2008, 7, 8, 9, 10)
 
-      output = '{"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby' + \
-               dd_lambda_layer_tag + '","t.a:val","t.b:v2"],"v":100}'
-      expect(Time).to receive(:now).and_return(now)
-      expect do
-        Datadog::Lambda.metric('m1', 100, "t.a": 'val', "t.b": 'v2')
-      end.to output("#{output}\n").to_stdout
+  describe '#metric' do
+    context 'when extension is running' do
+      subject(:lambdaModule) { Datadog::Lambda }
+      subject(:metrics_client) { lambdaModule.instance_variable_get(:@metrics_client) }
+      let(:statsd) { instance_double(Datadog::Statsd) }
+
+      before(:each) do
+        # Stub the extension_running? method to return true
+        allow(Datadog::Utils).to receive(:extension_running?).and_return(true)
+
+        # Mock Datadog::Statsd client
+        @previous_statsd = metrics_client.instance_variable_get(:@statsd)
+        metrics_client.instance_variable_set(:@statsd, statsd)
+      end
+
+      after(:each) do
+        # Reset Datadog::Statsd mock
+        metrics_client.instance_variable_set(:@statsd, @previous_statsd)
+      end
+
+      it 'sends metrics properly' do
+        # Expect the metric method to be called with the correct arguments
+        expect(lambdaModule).to receive(:metric).with('metric_name', 42, env: 'dev', region: 'nyc')
+
+        # Call the distribution method
+        lambdaModule.metric('metric_name', 42, env: 'dev', region: 'nyc')
+      end
     end
-    it 'prints a custom metric with a custom timestamp' do
-      custom_time = Time.utc(2008, 7, 8, 9, 11)
-      output = '{"e":1215508260,"m":"m1","t":["dd_lambda_layer:datadog-ruby' + \
-               dd_lambda_layer_tag + '","t.a:val","t.b:v2"],"v":100}'
-      expect do
-        Datadog::Lambda.metric('m1', 100, time: custom_time, "t.a": 'val', "t.b": 'v2')
-      end.to output("#{output}\n").to_stdout
+
+    context 'when extension is not running' do
+      it 'prints a custom metric' do
+        now = Time.utc(2008, 7, 8, 9, 10)
+        expect(Time).to receive(:now).and_return(now)
+
+        output = %({"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.a:val","t.b:v2"],"v":100})
+        expect do
+          Datadog::Lambda.metric('m1', 100, "t.a": 'val', "t.b": 'v2')
+        end.to output("#{output}\n").to_stdout
+      end
+
+      it 'prints a custom metric with a custom timestamp' do
+        custom_time = Time.utc(2008, 7, 8, 9, 11)
+
+        output = %({"e":1215508260,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.a:val","t.b:v2"],"v":100})
+        expect do
+          Datadog::Lambda.metric('m1', 100, time: custom_time, "t.a": 'val', "t.b": 'v2')
+        end.to output("#{output}\n").to_stdout
+      end
     end
   end
 
@@ -153,7 +213,7 @@ describe Datadog::Lambda do
       # rubocop:disable Metrics/LineLength
       expect do
         Datadog::Lambda.record_enhanced('invocations', ctx)
-      end.to output(/"dd_lambda_layer:datadog-ruby#{dd_lambda_layer_tag}","functionname:hello-dog-ruby-dev-helloRuby#{dd_lambda_layer_tag}","region:us-east-1","account_id:172597598159","memorysize:128",/).to_stdout
+      end.to output(/"dd_lambda_layer:datadog-ruby#{layer_tag}","functionname:hello-dog-ruby-dev-helloRuby#{layer_tag}","region:us-east-1","account_id:172597598159","memorysize:128",/).to_stdout
       # rubocop:enable Metrics/LineLength
     end
   end

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -162,18 +162,18 @@ describe Datadog::Lambda do
         now = Time.utc(2008, 7, 8, 9, 10)
         expect(Time).to receive(:now).and_return(now)
 
-        output = %({"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.a:val","t.b:v2"],"v":100})
+        output = %({"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.b:v2"],"v":100})
         expect do
-          Datadog::Lambda.metric('m1', 100, "t.a": 'val', "t.b": 'v2')
+          Datadog::Lambda.metric('m1', 100, "t.b": 'v2')
         end.to output("#{output}\n").to_stdout
       end
 
       it 'prints a custom metric with a custom timestamp' do
         custom_time = Time.utc(2008, 7, 8, 9, 11)
 
-        output = %({"e":1215508260,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.a:val","t.b:v2"],"v":100})
+        output = %({"e":1215508260,"m":"m1","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","t.b:v2"],"v":100})
         expect do
-          Datadog::Lambda.metric('m1', 100, time: custom_time, "t.a": 'val', "t.b": 'v2')
+          Datadog::Lambda.metric('m1', 100, time: custom_time, "t.b": 'v2')
         end.to output("#{output}\n").to_stdout
       end
     end

--- a/test/datadog/lambda/metrics.rb
+++ b/test/datadog/lambda/metrics.rb
@@ -24,7 +24,7 @@ describe Datadog::Metrics::Client do
       let(:statsd) { instance_double(Datadog::Statsd) }
 
       before(:each) do
-        # Mock the extension_running? method to return true
+        # Stub the extension_running? method to return true
         allow(Datadog::Utils).to receive(:extension_running?).and_return(true)
 
         # Mock Datadog::Statsd client
@@ -59,7 +59,7 @@ describe Datadog::Metrics::Client do
     end
 
     it 'prints metrics when extension is not running' do
-      # Mock the extension_running? method to return false
+      # Stub the extension_running? method to return false
       allow(Datadog::Utils).to receive(:extension_running?).and_return(false)
 
       now = Time.utc(2023, 1, 7, 12, 30)

--- a/test/datadog/lambda/metrics.rb
+++ b/test/datadog/lambda/metrics.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+require 'datadog/lambda'
+require 'datadog/statsd'
+require 'datadog/lambda/metrics'
+
+describe Datadog::Metrics::Client do
+  let(:client) { Datadog::Metrics::Client.instance }
+  let(:layer_tag) { Datadog::Lambda.dd_lambda_layer_tag }
+  let(:default_tags) { ["dd_lambda_layer:datadog-ruby#{layer_tag}"] }
+
+  describe '.instance' do
+    it 'returns the same instance' do
+      instance1 = Datadog::Metrics::Client.instance
+      instance2 = Datadog::Metrics::Client.instance
+      expect(instance1).to be(instance2)
+    end
+  end
+
+  describe '#distribution' do
+    it 'sends metrics through extension when extension is running' do
+      # Mock the extension_running? method to return true
+      allow(Datadog::Utils).to receive(:extension_running?).and_return(true)
+
+      # Mock Datadog::Statsd client
+      statsd = instance_double(Datadog::Statsd)
+      client.instance_variable_set(:@statsd, statsd)
+
+      expected_tags = default_tags.concat(['env:dev', 'region:nyc'])
+      # Expect the distribution method to be called with the correct arguments
+      expect(statsd).to receive(:distribution).with('metric_name', 42, tags: expected_tags)
+
+      # Call the distribution method
+      client.distribution('metric_name', 42, env: 'dev', region: 'nyc')
+    end
+
+    it 'prints metrics when extension is not running' do
+      # Mock the extension_running? method to return false
+      allow(Datadog::Utils).to receive(:extension_running?).and_return(false)
+
+      now = Time.utc(2023, 1, 7, 12, 30)
+      allow(Time).to receive(:now).and_return(now)
+
+      output = %({"e":1673094600,"m":"metric_name","t":["dd_lambda_layer:datadog-ruby#{layer_tag}","env:dev"],"v":42})
+      # Expect the metric to be printed to console (you may want to use an appropriate matcher for this)
+      expect { client.distribution('metric_name', 42, env: 'dev') }.to output("#{output}\n").to_stdout
+    end
+  end
+
+  describe '#get_tags' do
+    context 'when there a no tags' do
+      it 'should return the default tags' do
+        expect(client.get_tags).to match_array(default_tags)
+      end
+    end
+
+    context 'when tags are included' do
+      it 'should add the default tags to the sent ones' do
+        expected_tags = default_tags.concat(['env:dev', 'region:nyc'])
+        expect(client.get_tags(env: 'dev', region: 'nyc')).to match_array(expected_tags)
+      end
+    end
+  end
+end

--- a/test/datadog/lambda/metrics.rb
+++ b/test/datadog/lambda/metrics.rb
@@ -25,6 +25,7 @@ describe Datadog::Metrics::Client do
 
       # Mock Datadog::Statsd client
       statsd = instance_double(Datadog::Statsd)
+      previous_statsd = client.instance_variable_get(:@statsd)
       client.instance_variable_set(:@statsd, statsd)
 
       expected_tags = default_tags.concat(['env:dev', 'region:nyc'])
@@ -33,6 +34,9 @@ describe Datadog::Metrics::Client do
 
       # Call the distribution method
       client.distribution('metric_name', 42, env: 'dev', region: 'nyc')
+
+      # Reset Datadog::Statsd mock
+      client.instance_variable_set(:@statsd, previous_statsd)
     end
 
     it 'prints metrics when extension is not running' do
@@ -63,3 +67,5 @@ describe Datadog::Metrics::Client do
     end
   end
 end
+
+# rubocop:enable Metrics/BlockLength

--- a/test/datadog/lambda/metrics.rb
+++ b/test/datadog/lambda/metrics.rb
@@ -58,24 +58,6 @@ describe Datadog::Metrics::Client do
       end
     end
 
-    it 'doesnt send metric when statsd fails' do
-      allow(Datadog::Utils).to receive(:extension_running?).and_return(true)
-
-      statsd = instance_double(Datadog::Statsd)
-      previous_statsd = client.instance_variable_get(:@statsd)
-      client.instance_variable_set(:@statsd, statsd)
-
-      expected_tags = default_tags.concat(['env:dev', 'region:nyc'])
-      # Expect the distribution method to be called with the correct arguments
-      expect(statsd).to receive(:distribution).with('metric_name', 42, tags: expected_tags)
-
-      # Call the distribution method
-      client.distribution('metric_name', 42, env: 'dev', region: 'nyc')
-
-      # Reset Datadog::Statsd mock
-      client.instance_variable_set(:@statsd, previous_statsd)
-    end
-
     it 'prints metrics when extension is not running' do
       # Mock the extension_running? method to return false
       allow(Datadog::Utils).to receive(:extension_running?).and_return(false)

--- a/test/datadog/lambda/metrics.spec.rb
+++ b/test/datadog/lambda/metrics.spec.rb
@@ -5,6 +5,7 @@ require 'datadog/lambda'
 require 'datadog/statsd'
 require 'datadog/lambda/metrics'
 require 'datadog/lambda/utils/logger'
+require 'time'
 
 describe Datadog::Metrics::Client do
   subject(:client) { Datadog::Metrics::Client.instance }
@@ -16,6 +17,14 @@ describe Datadog::Metrics::Client do
       instance1 = Datadog::Metrics::Client.instance
       instance2 = Datadog::Metrics::Client.instance
       expect(instance1).to be(instance2)
+    end
+
+    it 'initialiazes Datadog::Statsd with the right parameters' do
+      # Stub the extension_running? method to return true
+      allow(Datadog::Utils).to receive(:extension_running?).and_return(true)
+
+      expect(Datadog::Statsd).to receive(:new).with(Datadog::Metrics::URL, Datadog::Metrics::PORT, single_thread: true)
+      Datadog::Metrics::Client.send(:new)
     end
   end
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allows custom metrics to be sent through the Datadog Extension.

### Motivation

Custom metrics were only supported when using the Datadog Lambda Forwarder.

### Testing Guidelines

- Added unit tests for metrics
- Tested manually on an AWS Lambda in both runtimes.

### Additional Notes

- Updated dependencies to include `dogstatsd-ruby` a DogStatsD client for Ruby.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
