### PR TITLE
fix: latest version of `dd-trace` broke the gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN gem build datadog-lambda
 
 # Install ddtrace gem
 RUN gem install datadog-lambda --install-dir "/opt/ruby/gems/$runtime"
-RUN gem install ddtrace -v 1.14.0 --install-dir "/opt/ruby/gems/$runtime"
+RUN gem install ddtrace -v 1.15.0 --install-dir "/opt/ruby/gems/$runtime"
 
 WORKDIR /opt
 # Remove native extension debase-ruby_core_source (25MB) runtimes below Ruby 2.6

--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dogstatsd-ruby', '~> 5.0'
   # We don't add this as a direct dependency, because it has
   # native modules that are difficult to package for lambda
-  spec.add_development_dependency 'ddtrace', '~>1.14.0'
+  spec.add_development_dependency 'ddtrace', '~>1.15.0'
 
   # Development dependencies
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/integration_tests/snapshots/logs/async-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby27.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.14.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.15.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/async-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby32.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.14.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.15.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/http-error_ruby27.log
+++ b/integration_tests/snapshots/logs/http-error_ruby27.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.14.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.15.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/http-error_ruby32.log
+++ b/integration_tests/snapshots/logs/http-error_ruby32.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.14.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.15.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/http-requests_ruby27.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby27.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.14.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.15.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/http-requests_ruby32.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby32.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.14.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.15.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby27.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby27.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.14.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.15.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby32.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby32.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.14.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.15.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 START

--- a/integration_tests/snapshots/logs/sync-metrics_ruby27.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby27.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.14.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux-gnu","version":"1.15.0","lang":"ruby","lang_version":"2.7.8","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-2.7.8","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/sync-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby32.log
@@ -3,7 +3,7 @@ D, [XXXX] DEBUG  -- : metrics are going to be handled by the forwarder
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
 END Duration: XXXX ms (init: XXXX) Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.14.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
+I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"x86_64-pc-linux","version":"1.15.0","lang":"ruby","lang_version":"3.2.2","env":null,"service":"runtime","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.2","health_metrics_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - PROFILING - {"profiling_enabled":false}
 I, [XXXX]  INFO XXXX[ddtrace] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false,"priority_sampling_enabled":false,"integration_aws_analytics_enabled":"false","integration_aws_analytics_sample_rate":"1.0","integration_aws_enabled":"true","integration_aws_service_name":"aws","integration_aws_peer_service":""}
 Processed APIGateway request

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -31,7 +31,7 @@ module Datadog
     # See https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#quickstart-for-ruby-applications
     def self.configure_apm
       require 'datadog/tracing'
-      require 'ddtrace/transport/io'
+      require 'datadog/tracing/transport/io'
 
       @patch_http = false
       # Needed to keep trace flushes on a single line
@@ -40,7 +40,7 @@ module Datadog
       Datadog.configure do |c|
         unless Datadog::Utils.extension_running?
           c.tracing.writer = Datadog::Tracing::SyncWriter.new(
-            transport: Datadog::Transport::IO.default
+            transport: Datadog::Tracing::Transport::IO.default
           )
         end
         c.tags = { "_dd.origin": 'lambda' }

--- a/lib/datadog/lambda/utils/extension.rb
+++ b/lib/datadog/lambda/utils/extension.rb
@@ -49,7 +49,7 @@ module Datadog
 
       request = Net::HTTP::Post.new(END_INVOCATION_URI)
       request.body = response.to_json
-      request[Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST] = 1
+      request[Datadog::Core::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST] = 1
 
       trace = Datadog::Tracing.active_trace
       Tracing::Propagation::HTTP.inject!(trace, request)
@@ -64,7 +64,7 @@ module Datadog
       {
         # Header used to avoid tracing requests that are internal to
         # Datadog products.
-        Datadog::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST.to_sym => 'true'
+        Datadog::Core::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST.to_sym => 'true'
       }
     end
   end


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Upgrades `dd-trace` to `1.15.0`.

### Motivation

Users installing the gem can bring their own tracer. [dd-trace-rb#3150](https://github.com/DataDog/dd-trace-rb/pull/3150) made breaking changes for us.

### Testing Guidelines

Updated snapshots.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
