### PR TITLE
dd-trace cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
@@ -31,7 +31,7 @@ jobs:
         ruby-version: [3.2, 3.3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 14.15
         uses: actions/setup-node@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require 'rspec/core/rake_task'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'datadog/lambda/version'
 
+task default: :test
+
 task :build do
   system 'gem build datadog-lambda.gemspec'
 end

--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   # We don't add this as a direct dependency, because it has
   # native modules that are difficult to package for lambda
-  spec.add_development_dependency 'ddtrace', '~>1.23.3'
+  spec.add_development_dependency 'datadog', '~> 2.0'
 
   # Development dependencies
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -114,9 +114,9 @@ module Datadog
         datadog_lambda: Datadog::Lambda::VERSION::STRING.to_sym
       }
       begin
-        tags[:dd_trace] = Gem.loaded_specs['ddtrace'].version
+        tags[:datadog] = Gem.loaded_specs['datadog'].version
       rescue StandardError
-        Datadog::Utils.logger.debug 'dd-trace unavailable'
+        Datadog::Utils.logger.debug 'datadog unavailable'
       end
       # If we have an alias...
       unless function_alias.nil?
@@ -187,7 +187,7 @@ module Datadog
 
       # Only initialize listener if Tracing enabled.
       unless Datadog::Tracing.enabled?
-        Datadog::Utils.logger.debug 'dd-trace unavailable'
+        Datadog::Utils.logger.debug 'datadog unavailable'
         return nil
       end
 

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -56,7 +56,6 @@ module Datadog
     # @param context [Object] lambda context
     # @param block [Proc] implementation of the handler function.
     def self.wrap(event, context, &block)
-      Datadog::Utils.update_log_level
       @listener ||= initialize_listener
       record_enhanced('invocations', context)
       begin

--- a/lib/datadog/lambda/trace/ddtrace.rb
+++ b/lib/datadog/lambda/trace/ddtrace.rb
@@ -2,9 +2,9 @@
 
 # `ddtrace`` is an optional dependency for the ruby package
 begin
-  require 'ddtrace'
+  require 'datadog'
 rescue LoadError
-  Datadog::Utils.logger.debug 'dd-trace unavailable'
+  Datadog::Utils.logger.debug 'datadog unavailable'
 end
 
 module Datadog

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -40,7 +40,6 @@ module Datadog
         options[:tags]['_dd.parent_source'] = source if source && source != 'ddtrace'
         options[:resource] = @function_name
         options[:service] = 'aws.lambda'
-        options[:span_type] = 'serverless'
         Datadog::Trace.apply_datadog_trace_context(Datadog::Trace.trace_context)
 
         trace_digest = Datadog::Utils.send_start_invocation_request(event:)

--- a/lib/datadog/lambda/utils/logger.rb
+++ b/lib/datadog/lambda/utils/logger.rb
@@ -14,21 +14,19 @@ module Datadog
   # Utils contains utility functions shared between modules
   module Utils
     def self.logger
-      @logger ||= Logger.new($stdout)
-    end
-
-    def self.update_log_level
-      log_level = (ENV['DD_LOG_LEVEL'] || 'error').downcase
-      logger.level = case log_level
-                     when 'debug'
-                       Logger::DEBUG
-                     when 'info'
-                       Logger::INFO
-                     when 'warn'
-                       Logger::WARN
-                     else
-                       Logger::ERROR
-                     end
+      @logger ||= Logger.new($stderr).tap do |logger|
+        log_level = (ENV['DD_LOG_LEVEL'] || 'error').downcase
+        logger.level = case log_level
+                       when 'debug'
+                         Logger::DEBUG
+                       when 'info'
+                         Logger::INFO
+                       when 'warn'
+                         Logger::WARN
+                       else
+                         Logger::ERROR
+                       end
+      end
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?

- upgrade deprecated GitHub action versions for `actions/checkout` and `actions/setup-node`
- add default task for Rakefile (`:test` task)
- update gemspec to use `datadog` gem `~> 2.0`
- update logging references to "dd-trace" to "datadog"
- remove `:span_type` from tracer options
- set log level on init instead of on-demand

### Motivation

current version isn't compatible with `datadog` gem (v2)

### Testing Guidelines

```bash
bundle exec rake test
```

### Additional Notes

N/A

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
