### PR TITLE
fix(gitlab): install ruby in ci image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,10 +12,10 @@ ci image:
   tags: ["arch:arm64"]
   needs: []
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
-      changes:
-        - .gitlab/Dockerfile
-      when: on_success
+    # - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
+    #   changes:
+    #     - .gitlab/Dockerfile
+    #   when: on_success
   variables:
     DOCKER_TARGET: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,14 +12,24 @@ ci image:
   tags: ["arch:arm64"]
   needs: []
   rules:
-    # - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
-    #   changes:
-    #     - .gitlab/Dockerfile
-    #   when: on_success
+    - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
+      changes:
+        - .gitlab/Dockerfile
+      when: on_success
   variables:
     DOCKER_TARGET: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
   script:
     - docker buildx build --platform linux/amd64,linux/arm64 --no-cache --pull --push --tag ${DOCKER_TARGET} -f .gitlab/Dockerfile .
+
+test:
+  stage: build
+  tags: ["arch:amd64"]
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
+  cache: []
+  script:
+    - gem --version
+    - bundle --version
+    - ruby --version
 
 .go-cache: &go-cache
   key: datadog-lambda-rb-go-cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,16 +21,6 @@ ci image:
   script:
     - docker buildx build --platform linux/amd64,linux/arm64 --no-cache --pull --push --tag ${DOCKER_TARGET} -f .gitlab/Dockerfile .
 
-test:
-  stage: build
-  tags: ["arch:amd64"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
-  cache: []
-  script:
-    - gem --version
-    - bundle --version
-    - ruby --version
-
 .go-cache: &go-cache
   key: datadog-lambda-rb-go-cache
   policy: pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ ci image:
 test:
   stage: build
   tags: ["arch:amd64"]
-  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
+  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
   cache: []
   script:
     - gem --version

--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -3,6 +3,9 @@ FROM registry.ddbuild.io/images/docker:24.0.5
 RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
   curl gcc gnupg g++ make cmake unzip openssl g++ uuid-runtime xxd ca-certificates
 
+# Install Ruby 3.3
+RUN apt-get install ruby-full -y
+
 # Install NodeJS 18.x
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Install Ruby in the CI image so `publish rubygems` works

### Motivation

It failed on last released, had to do it manually

### Testing Guidelines

I tested with a manual test job

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
