### PR TITLE
Switch nokogiri dependency to dev dependency.

### DIFF
--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
 
   ruby_version = Gem::Version.new(RUBY_VERSION) # rubocop:disable Gemspec/RubyVersionGlobalsUsage
   if ruby_version >= Gem::Version.new('3.3')
-    spec.add_dependency 'nokogiri', '~> 1.16.0'
+    spec.add_development_dependency 'nokogiri', '~> 1.16.0'
   else
-    spec.add_dependency 'nokogiri', '~> 1.15.6'
+    spec.add_development_dependency 'nokogiri', '~> 1.15.6'
   end
 
   # We don't add this as a direct dependency, because it has


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Update `nokogiri` to be a dev dependency instead of a direct dependency. It is a dependency of `reverse_markdown` which is a dependency of `solargraph` which itself is just a dev dependency.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

https://github.com/DataDog/datadog-lambda-rb/issues/107

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
