### PR TITLE
Trigger layer version update in documentation

### DIFF
--- a/.gitlab/template.yaml.tpl
+++ b/.gitlab/template.yaml.tpl
@@ -155,6 +155,23 @@ publish rubygems:
   script:
     - .gitlab/scripts/publish_rubygems.sh
 
+update-layer-versions-docs:
+  stage: publish
+  trigger:
+    project: DataDog/serverless-ci
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  needs:
+  {{ range $runtime := (ds "runtimes").runtimes }}
+    - publish layer prod ({{ $runtime.ruby_version }}, {{ $runtime.arch}})
+  {{- end }}
+    - publish rubygems
+  variables:
+    RUN_LAMBDA_LAYER_DOCUMENTATION: "true"
+    RUN_LAMBDA_DATADOG_CI: "true"
+    RUN_LAMBDA_UI_LAYER_VERSIONS: "true"
+    RUN_LAMBDA_RUNTIMES: "true"
+
 layer bundle:
   stage: build
   tags: ["arch:amd64"]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds Gitlab job to release pipelines to trigger DataDog/serverless-ci pipeline which will generate a PR for updating the layer version in public documentation. Then, serverless ONE will review and merge this PR.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Keeps public facing documentation up-to-date.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
