### PR TITLE
[APPSEC-61865] Add inferred spans for API Gateway

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 3.2
+  Exclude:
+    - 'test/**/*'
 
 Metrics/MethodLength:
   Max: 20

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -13,6 +13,7 @@ require 'datadog/lambda/metrics'
 require 'datadog/lambda/trace/listener'
 require 'datadog/lambda/utils/logger'
 require 'datadog/lambda/utils/extension'
+require 'datadog/lambda/utils/version'
 require 'datadog/lambda/trace/patch_http'
 require 'json'
 require 'datadog/lambda/version'
@@ -113,10 +114,8 @@ module Datadog
         resource: context.function_name,
         datadog_lambda: Datadog::Lambda::VERSION::STRING.to_sym
       }
-      begin
-        tags[:dd_trace] = Gem.loaded_specs['datadog'].version
-      rescue StandardError
-        Datadog::Utils.logger.debug 'datadog unavailable'
+      if (dd_trace = Datadog::Utils.dd_trace_version)
+        tags[:dd_trace] = dd_trace
       end
       # If we have an alias...
       unless function_alias.nil?

--- a/lib/datadog/lambda/event_source.rb
+++ b/lib/datadog/lambda/event_source.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+#
+
+require_relative 'event_source/api_gateway_v1'
+require_relative 'event_source/api_gateway_v2'
+
+module Datadog
+  module Lambda
+    # Detects and parses Lambda event payloads into a uniform interface.
+    module EventSource
+      SOURCES = [ApiGatewayV1, ApiGatewayV2].freeze
+
+      def self.for(event)
+        klass = SOURCES.find { |source| source.match?(event) }
+        klass&.new(event)
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/event_source/api_gateway_v1.rb
+++ b/lib/datadog/lambda/event_source/api_gateway_v1.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+#
+
+module Datadog
+  module Lambda
+    module EventSource
+      # Parses API Gateway REST API (v1) Lambda proxy integration events
+      # into a uniform interface.
+      #
+      # @see https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+      class ApiGatewayV1
+        class << self
+          def match?(payload)
+            api_gateway?(payload) && payload.key?('httpMethod')
+          end
+
+          private
+
+          def api_gateway?(payload)
+            payload.is_a?(Hash) &&
+              payload.key?('requestContext') && payload['requestContext'].key?('stage')
+          end
+        end
+
+        def initialize(payload)
+          @payload = payload
+          @request_context = payload.fetch('requestContext', {})
+        end
+
+        def method = @payload['httpMethod']
+        def path = @payload.fetch('path', '/')
+        def resource_path = @request_context.fetch('resourcePath', path)
+        def domain = @request_context['domainName']
+        def api_id = @request_context['apiId']
+        def stage = @request_context['stage']
+        def request_time_ms = @request_context['requestTimeEpoch']
+        def user_agent = @request_context.dig('identity', 'userAgent')
+
+        def http_url
+          return path unless domain
+
+          "https://#{domain}#{path}"
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/event_source/api_gateway_v2.rb
+++ b/lib/datadog/lambda/event_source/api_gateway_v2.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+#
+
+module Datadog
+  module Lambda
+    module EventSource
+      # Parses API Gateway HTTP API (v2) Lambda proxy integration events
+      # into a uniform interface.
+      #
+      # @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
+      class ApiGatewayV2
+        class << self
+          def match?(payload)
+            api_gateway?(payload) && payload.key?('routeKey')
+          end
+
+          private
+
+          def api_gateway?(payload)
+            payload.is_a?(Hash) &&
+              payload.key?('requestContext') && payload['requestContext'].key?('stage')
+          end
+        end
+
+        def initialize(payload)
+          @payload = payload
+          @request_context = payload.fetch('requestContext', {})
+          @http = @request_context.fetch('http', {})
+        end
+
+        def method = @http['method']
+        def path = @payload.fetch('rawPath', '/')
+        def resource_path = @payload['routeKey']&.sub(/\A[A-Z]+ /, '') || path
+        def domain = @request_context['domainName']
+        def api_id = @request_context['apiId']
+        def stage = @request_context['stage']
+        def request_time_ms = @request_context['timeEpoch']
+        def user_agent = @http['userAgent']
+
+        def http_url
+          return path unless domain
+
+          "https://#{domain}#{path}"
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/inferred_span.rb
+++ b/lib/datadog/lambda/inferred_span.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+
+require_relative 'event_source'
+require_relative 'inferred_span/api_gateway_v1'
+require_relative 'inferred_span/api_gateway_v2'
+
+module Datadog
+  module Lambda
+    # Creates inferred spans representing upstream services
+    # in the Lambda invocation path (e.g. API Gateway).
+    #
+    # @see https://docs.datadoghq.com/tracing/trace_collection/proxy_setup/apigateway/
+    module InferredSpan
+      ARN_REGION_INDEX = 3
+      ARN_SPLIT_LIMIT = 5
+
+      class << self
+        def try_create(event_source, request_context, trace_digest)
+          return unless event_source
+
+          inferred = case event_source
+                     when EventSource::ApiGatewayV1 then ApiGatewayV1.new(event_source)
+                     when EventSource::ApiGatewayV2 then ApiGatewayV2.new(event_source)
+                     end
+          return unless inferred
+
+          start_span(inferred, request_context: request_context, trace_digest: trace_digest)
+        rescue StandardError => e
+          Datadog::Utils.logger.debug "failed to create inferred span: #{e}"
+          nil
+        end
+
+        private
+
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def start_span(event_source, request_context:, trace_digest:)
+          resource = "#{event_source.method} #{event_source.resource_path}"
+
+          tags = {
+            'http.method' => event_source.method,
+            'http.url' => event_source.http_url,
+            'http.route' => event_source.resource_path,
+            'endpoint' => event_source.path,
+            'resource_names' => resource,
+            'span.kind' => 'server',
+            'apiid' => event_source.api_id,
+            'apiname' => event_source.api_id,
+            'stage' => event_source.stage,
+            'request_id' => request_context.aws_request_id,
+            'dd_resource_key' => resource_key_for(event_source, request_context),
+            'http.useragent' => event_source.user_agent,
+            '_inferred_span.synchronicity' => 'sync',
+            '_inferred_span.tag_source' => 'self'
+          }
+          tags.compact!
+
+          options = { service: event_source.domain, resource: resource, type: 'web', tags: tags }
+          options[:continue_from] = trace_digest if trace_digest
+          options[:start_time] = ms_to_time(event_source.request_time_ms) if event_source.request_time_ms
+
+          span = Datadog::Tracing.trace(event_source.span_name, **options)
+          span.set_metric('_dd._inferred_span', 1.0)
+          span
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+        def resource_key_for(event_source, request_context)
+          arn = request_context.invoked_function_arn.to_s
+          return unless arn.include?(':')
+
+          region = arn.split(':', ARN_SPLIT_LIMIT)[ARN_REGION_INDEX]
+          return unless event_source.api_id && event_source.stage
+
+          stage_path = "/#{event_source.arn_path_prefix}/#{event_source.api_id}/stages/#{event_source.stage}"
+          "arn:aws:apigateway:#{region}::#{stage_path}"
+        end
+
+        def ms_to_time(milliseconds)
+          Time.at(milliseconds / 1000.0)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/inferred_span/api_gateway_v1.rb
+++ b/lib/datadog/lambda/inferred_span/api_gateway_v1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+
+require 'forwardable'
+
+module Datadog
+  module Lambda
+    module InferredSpan
+      # Wraps EventSource::ApiGatewayV1 with additional span-specific attributes.
+      class ApiGatewayV1
+        extend Forwardable
+
+        def_delegators :@event_source,
+                       :method, :path, :resource_path, :domain,
+                       :api_id, :stage, :request_time_ms, :user_agent,
+                       :http_url
+
+        def initialize(event_source)
+          @event_source = event_source
+        end
+
+        def span_name = 'aws.apigateway'
+        def arn_path_prefix = 'restapis'
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/inferred_span/api_gateway_v2.rb
+++ b/lib/datadog/lambda/inferred_span/api_gateway_v2.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+
+require 'forwardable'
+
+module Datadog
+  module Lambda
+    module InferredSpan
+      # Wraps EventSource::ApiGatewayV2 with additional span-specific attributes.
+      class ApiGatewayV2
+        extend Forwardable
+
+        def_delegators :@event_source,
+                       :method, :path, :resource_path, :domain,
+                       :api_id, :stage, :request_time_ms, :user_agent,
+                       :http_url
+
+        def initialize(event_source)
+          @event_source = event_source
+        end
+
+        def span_name = 'aws.httpapi'
+        def arn_path_prefix = 'apis'
+      end
+    end
+  end
+end

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -28,7 +28,7 @@ module Datadog
         Datadog::Trace.patch_http if patch_http
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def on_start(event:, request_context:, cold_start:)
         @span = nil
         @inferred_span = nil
@@ -58,7 +58,7 @@ module Datadog
 
         Datadog::Trace.apply_datadog_trace_context(Datadog::Trace.trace_context)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def on_end(response:, request_context:)
         Datadog::Utils.send_end_invocation_request(span_id: @span.id, response:, request_context:)

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -11,12 +11,13 @@
 require 'datadog/lambda/trace/context'
 require 'datadog/lambda/trace/patch_http'
 require 'datadog/lambda/trace/ddtrace'
+require 'datadog/lambda/event_source'
+require 'datadog/lambda/inferred_span'
 
 module Datadog
   module Trace
     # TraceListener tracks tracing context information
     class Listener
-      @trace = nil
       def initialize(handler_name:, function_name:, patch_http:,
                      merge_xray_traces:)
         @handler_name = handler_name
@@ -26,8 +27,11 @@ module Datadog
         Datadog::Trace.patch_http if patch_http
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def on_start(event:, request_context:, cold_start:)
+        @span = nil
+        @inferred_span = nil
+
         trace_context = Datadog::Trace.extract_trace_context(event, @merge_xray_traces)
         Datadog::Trace.trace_context = trace_context
         Datadog::Utils.logger.debug "extracted trace context #{trace_context}"
@@ -43,19 +47,23 @@ module Datadog
         options[:type] = 'serverless'
 
         trace_digest = Datadog::Utils.send_start_invocation_request(event:, request_context:)
-        # Only continue trace from a new one if it exist, or else,
-        # it will create a new trace, which is not ideal here.
-        options[:continue_from] = trace_digest if trace_digest
 
-        @trace = Datadog::Tracing.trace('aws.lambda', **options)
+        event_source = Datadog::Lambda::EventSource.for(event)
+        @inferred_span = Datadog::Lambda::InferredSpan.try_create(event_source, request_context, trace_digest)
+        options[:continue_from] = trace_digest if trace_digest && @inferred_span.nil?
+
+        @span = Datadog::Tracing.trace('aws.lambda', **options)
 
         Datadog::Trace.apply_datadog_trace_context(Datadog::Trace.trace_context)
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def on_end(response:, request_context:)
-        Datadog::Utils.send_end_invocation_request(response:, span_id: @trace.id, request_context:)
-        @trace&.finish
+        Datadog::Utils.send_end_invocation_request(span_id: @span.id, response:, request_context:)
+
+        # NOTE: lambda span must finish before inferred span (its parent)
+        @span&.finish
+        @inferred_span&.finish
       end
 
       private

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -63,6 +63,11 @@ module Datadog
       def on_end(response:, request_context:)
         Datadog::Utils.send_end_invocation_request(span_id: @span.id, response:, request_context:)
 
+        if response.is_a?(Hash) && (status = response[:statusCode])
+          @span&.set_tag('http.status_code', status)
+          @inferred_span&.set_tag('http.status_code', status)
+        end
+
         # NOTE: lambda span must finish before inferred span (its parent)
         @span&.finish
         @inferred_span&.finish

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -13,6 +13,7 @@ require 'datadog/lambda/trace/patch_http'
 require 'datadog/lambda/trace/ddtrace'
 require 'datadog/lambda/event_source'
 require 'datadog/lambda/inferred_span'
+require 'datadog/lambda/utils/version'
 
 module Datadog
   module Trace
@@ -53,6 +54,7 @@ module Datadog
         options[:continue_from] = trace_digest if trace_digest && @inferred_span.nil?
 
         @span = Datadog::Tracing.trace('aws.lambda', **options)
+        set_http_tags(@span, event_source) if event_source
 
         Datadog::Trace.apply_datadog_trace_context(Datadog::Trace.trace_context)
       end
@@ -68,22 +70,39 @@ module Datadog
 
       private
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def get_option_tags(request_context:, cold_start:)
         function_arn = request_context.invoked_function_arn.to_s.downcase
         tk = function_arn.split(':')
         function_arn = tk.length > 7 ? tk[0, 7].join(':') : function_arn
         function_version = tk.length > 7 ? tk[7] : '$LATEST'
         function_name = request_context.function_name
-        {
+
+        result = {
           tags: {
+            'span.kind' => 'server',
             cold_start:,
             function_arn:,
             function_version:,
             request_id: request_context.aws_request_id,
             functionname: function_name.nil? || function_name.empty? ? nil : function_name.downcase,
-            resource_names: function_name
+            resource_names: function_name,
+            datadog_lambda: Datadog::Lambda::VERSION::STRING
           }
         }
+
+        if (dd_trace = Datadog::Utils.dd_trace_version)
+          result[:tags][:dd_trace] = dd_trace
+        end
+
+        result
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def set_http_tags(span, event_source)
+        span.set_tag('http.method', event_source.method)
+        span.set_tag('http.url', event_source.http_url)
+        span.set_tag('http.useragent', event_source.user_agent)
       end
     end
   end

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -42,8 +42,8 @@ module Datadog
         context = Datadog::Trace.trace_context
         source = context[:source] if context
         options[:tags]['_dd.parent_source'] = source if source && source != 'ddtrace'
-        options[:resource] = 'dd-tracer-serverless-span'
-        options[:service] = 'aws.lambda'
+        options[:resource] = @function_name || 'aws.lambda'
+        options[:service] = Datadog.configuration.service || @function_name || 'aws.lambda'
         options[:type] = 'serverless'
 
         trace_digest = Datadog::Utils.send_start_invocation_request(event:, request_context:)

--- a/lib/datadog/lambda/utils/version.rb
+++ b/lib/datadog/lambda/utils/version.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+#
+
+require_relative 'logger'
+
+module Datadog
+  # Utils contains utility functions shared between modules
+  module Utils
+    def self.dd_trace_version
+      Gem.loaded_specs['datadog']&.version&.to_s
+    rescue StandardError
+      logger.debug('datadog unavailable')
+      nil
+    end
+  end
+end

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -145,6 +145,15 @@ describe Datadog::Lambda do
     end
   end
 
+  context 'when datadog gem is unavailable' do
+    before { allow(Datadog::Utils).to receive(:dd_trace_version).and_return(nil) }
+
+    it 'excludes dd_trace from enhanced tags' do
+      tags = Datadog::Lambda.gen_enhanced_tags(ctx)
+      expect(tags).not_to have_key(:dd_trace)
+    end
+  end
+
   describe '#metric' do
     context 'when extension is running' do
       subject(:lambda_module) { Datadog::Lambda }

--- a/test/datadog/lambda/event_source/api_gateway_v1.spec.rb
+++ b/test/datadog/lambda/event_source/api_gateway_v1.spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/event_source/api_gateway_v1'
+
+RSpec.describe Datadog::Lambda::EventSource::ApiGatewayV1 do
+  subject(:source) { described_class.new(payload) }
+
+  let(:payload) do
+    {
+      'httpMethod' => 'GET',
+      'path' => '/users/42',
+      'requestContext' => {
+        'stage' => 'prod',
+        'domainName' => 'api.example.com',
+        'apiId' => 'abc123',
+        'resourcePath' => '/users/{id}',
+        'requestTimeEpoch' => 1_700_000_000_000,
+        'identity' => {'userAgent' => 'TestAgent/1.0'},
+      },
+    }
+  end
+
+  describe '.match?' do
+    it { expect(described_class.match?('not a hash')).to be(false) }
+    it { expect(described_class.match?({})).to be(false) }
+    it { expect(described_class.match?('requestContext' => {'stage' => 'prod'})).to be(false) }
+    it { expect(described_class.match?('httpMethod' => 'GET')).to be(false) }
+
+    it 'matches a v1 proxy integration event' do
+      expect(
+        described_class.match?('httpMethod' => 'GET', 'requestContext' => {'stage' => 'prod'})
+      ).to be(true)
+    end
+  end
+
+  context 'when all fields are present' do
+    it { expect(source.method).to eq('GET') }
+    it { expect(source.path).to eq('/users/42') }
+    it { expect(source.resource_path).to eq('/users/{id}') }
+    it { expect(source.domain).to eq('api.example.com') }
+    it { expect(source.api_id).to eq('abc123') }
+    it { expect(source.stage).to eq('prod') }
+    it { expect(source.request_time_ms).to eq(1_700_000_000_000) }
+    it { expect(source.user_agent).to eq('TestAgent/1.0') }
+  end
+
+  context 'when optional fields are missing' do
+    let(:payload) { {'httpMethod' => 'POST', 'requestContext' => {'stage' => 'dev'}} }
+
+    it { expect(source.path).to eq('/') }
+    it { expect(source.resource_path).to eq('/') }
+    it { expect(source.domain).to be_nil }
+    it { expect(source.api_id).to be_nil }
+    it { expect(source.stage).to eq('dev') }
+    it { expect(source.request_time_ms).to be_nil }
+    it { expect(source.user_agent).to be_nil }
+  end
+end

--- a/test/datadog/lambda/event_source/api_gateway_v2.spec.rb
+++ b/test/datadog/lambda/event_source/api_gateway_v2.spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/event_source/api_gateway_v2'
+
+RSpec.describe Datadog::Lambda::EventSource::ApiGatewayV2 do
+  subject(:source) { described_class.new(payload) }
+
+  let(:payload) do
+    {
+      'rawPath' => '/users/42',
+      'routeKey' => 'GET /users/{id}',
+      'requestContext' => {
+        'stage' => 'prod',
+        'domainName' => 'api.example.com',
+        'apiId' => 'xyz789',
+        'timeEpoch' => 1_700_000_000_000,
+        'http' => {'method' => 'GET', 'userAgent' => 'TestAgent/2.0'},
+      },
+    }
+  end
+
+  describe '.match?' do
+    it { expect(described_class.match?('not a hash')).to be(false) }
+    it { expect(described_class.match?({})).to be(false) }
+    it { expect(described_class.match?('requestContext' => {'stage' => 'prod'})).to be(false) }
+    it { expect(described_class.match?('routeKey' => 'GET /test')).to be(false) }
+
+    it 'matches a v2 proxy integration event' do
+      expect(
+        described_class.match?('routeKey' => 'GET /test', 'requestContext' => {'stage' => 'prod'})
+      ).to be(true)
+    end
+  end
+
+  context 'when all fields are present' do
+    it { expect(source.method).to eq('GET') }
+    it { expect(source.path).to eq('/users/42') }
+    it { expect(source.resource_path).to eq('/users/{id}') }
+    it { expect(source.domain).to eq('api.example.com') }
+    it { expect(source.api_id).to eq('xyz789') }
+    it { expect(source.stage).to eq('prod') }
+    it { expect(source.request_time_ms).to eq(1_700_000_000_000) }
+    it { expect(source.user_agent).to eq('TestAgent/2.0') }
+  end
+
+  context 'when routeKey has no method prefix' do
+    let(:payload) do
+      {
+        'rawPath' => '/test',
+        'routeKey' => '$default',
+        'requestContext' => {
+          'stage' => 'prod',
+          'http' => {'method' => 'GET'},
+        },
+      }
+    end
+
+    it { expect(source.resource_path).to eq('$default') }
+  end
+
+  context 'when optional fields are missing' do
+    let(:payload) { {'routeKey' => 'POST /data', 'requestContext' => {'stage' => 'dev'}} }
+
+    it { expect(source.path).to eq('/') }
+    it { expect(source.resource_path).to eq('/data') }
+    it { expect(source.domain).to be_nil }
+    it { expect(source.api_id).to be_nil }
+    it { expect(source.stage).to eq('dev') }
+    it { expect(source.request_time_ms).to be_nil }
+    it { expect(source.user_agent).to be_nil }
+    it { expect(source.method).to be_nil }
+  end
+end

--- a/test/datadog/lambda/inferred_span.spec.rb
+++ b/test/datadog/lambda/inferred_span.spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda'
+require 'datadog/lambda/event_source'
+require 'datadog/lambda/inferred_span'
+require_relative '../lambdacontextversion'
+
+RSpec.describe Datadog::Lambda::InferredSpan do
+  let(:request_context) do
+    instance_double(
+      LambdaContextVersion,
+      aws_request_id: 'test-request-id',
+      invoked_function_arn: 'arn:aws:lambda:us-east-1:123456789:function:test-function'
+    )
+  end
+
+  describe '.try_create' do
+    subject(:span) { described_class.try_create(event_source, request_context, nil) }
+
+    let(:event_source) { Datadog::Lambda::EventSource.for(event) }
+
+    context 'when event is not a Hash' do
+      let(:event) { 'not a hash' }
+
+      it { expect(span).to be_nil }
+    end
+
+    context 'when event has no requestContext' do
+      let(:event) { {} }
+
+      it { expect(span).to be_nil }
+    end
+
+    context 'when event has requestContext without stage' do
+      let(:event) { {'requestContext' => {'apiId' => 'abc'}} }
+
+      it { expect(span).to be_nil }
+    end
+
+    context 'when event has no httpMethod or routeKey' do
+      let(:event) { {'requestContext' => {'stage' => 'prod'}} }
+
+      it { expect(span).to be_nil }
+    end
+
+    context 'when event is API Gateway v1' do
+      let(:event) do
+        {
+          'httpMethod' => 'GET',
+          'path' => '/test',
+          'requestContext' => {
+            'stage' => 'prod',
+            'domainName' => 'api.example.com',
+            'apiId' => 'abc123',
+            'resourcePath' => '/test',
+            'requestTimeEpoch' => 1_700_000_000_000,
+            'identity' => {'userAgent' => 'TestAgent/1.0', 'sourceIp' => '1.2.3.4'},
+          },
+        }
+      end
+
+      it 'creates a span representing the API Gateway' do
+        aggregate_failures('span identity') do
+          expect(span.name).to eq('aws.apigateway')
+          expect(span.service).to eq('api.example.com')
+          expect(span.resource).to eq('GET /test')
+          expect(span.type).to eq('web')
+          expect(span.start_time).to eq(Time.at(1_700_000_000))
+        end
+      end
+
+      it 'sets tags for endpoint discovery' do
+        aggregate_failures('http tags') do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.url')).to eq('https://api.example.com/test')
+          expect(span.get_tag('http.route')).to eq('/test')
+          expect(span.get_tag('http.useragent')).to eq('TestAgent/1.0')
+          expect(span.get_tag('span.kind')).to eq('server')
+        end
+      end
+
+      it 'sets tags for API Gateway resource correlation' do
+        aggregate_failures('gateway tags') do
+          expect(span.get_tag('apiid')).to eq('abc123')
+          expect(span.get_tag('stage')).to eq('prod')
+          expect(span.get_tag('request_id')).to eq('test-request-id')
+          expect(span.get_tag('dd_resource_key')).to eq(
+            'arn:aws:apigateway:us-east-1::/restapis/abc123/stages/prod'
+          )
+        end
+      end
+
+      it 'marks the span as inferred' do
+        aggregate_failures('inferred span markers') do
+          expect(span.get_metric('_dd._inferred_span')).to eq(1.0)
+          expect(span.get_tag('_inferred_span.synchronicity')).to eq('sync')
+          expect(span.get_tag('_inferred_span.tag_source')).to eq('self')
+        end
+      end
+
+      context 'when trace_digest is provided' do
+        before { allow(Datadog::Tracing).to receive(:trace).and_return(span_double) }
+
+        let(:span_double) { instance_double(Datadog::Tracing::SpanOperation, set_metric: nil) }
+        let(:trace_digest) { instance_double(Datadog::Tracing::TraceDigest) }
+
+        subject(:span) { described_class.try_create(event_source, request_context, trace_digest) }
+
+        it 'passes trace_digest as continue_from' do
+          span
+          expect(Datadog::Tracing).to have_received(:trace).with(
+            'aws.apigateway', hash_including(continue_from: trace_digest)
+          )
+        end
+      end
+
+      context 'when domainName is missing' do
+        let(:event) do
+          {
+            'httpMethod' => 'GET',
+            'path' => '/test',
+            'requestContext' => {
+              'stage' => 'prod',
+              'apiId' => 'abc123',
+              'resourcePath' => '/test',
+              'requestTimeEpoch' => 1_700_000_000_000,
+            },
+          }
+        end
+
+        it { expect(span.get_tag('http.url')).to eq('/test') }
+        it { expect(span.service).not_to eq('api.example.com') }
+      end
+
+      context 'when requestTimeEpoch is missing' do
+        let(:event) do
+          {
+            'httpMethod' => 'GET',
+            'path' => '/test',
+            'requestContext' => {
+              'stage' => 'prod',
+              'domainName' => 'api.example.com',
+              'apiId' => 'abc123',
+              'resourcePath' => '/test',
+            },
+          }
+        end
+
+        it 'still creates the span' do
+          expect(span).not_to be_nil
+        end
+      end
+
+      context 'when apiId is missing' do
+        let(:event) do
+          {
+            'httpMethod' => 'GET',
+            'path' => '/test',
+            'requestContext' => {
+              'stage' => 'prod',
+              'domainName' => 'api.example.com',
+              'resourcePath' => '/test',
+            },
+          }
+        end
+
+        it 'omits API Gateway resource tags' do
+          aggregate_failures('tags derived from apiId') do
+            expect(span).not_to have_tag('apiid')
+            expect(span).not_to have_tag('apiname')
+            expect(span).not_to have_tag('dd_resource_key')
+          end
+        end
+      end
+    end
+
+    context 'when event is API Gateway v2' do
+      let(:event) do
+        {
+          'rawPath' => '/test',
+          'routeKey' => 'GET /test',
+          'requestContext' => {
+            'stage' => 'prod',
+            'domainName' => 'api.example.com',
+            'apiId' => 'xyz789',
+            'timeEpoch' => 1_700_000_000_000,
+            'http' => {'method' => 'GET', 'userAgent' => 'TestAgent/2.0'},
+          },
+        }
+      end
+
+      it 'creates a span representing the HTTP API' do
+        aggregate_failures('span identity') do
+          expect(span.name).to eq('aws.httpapi')
+          expect(span.service).to eq('api.example.com')
+          expect(span.resource).to eq('GET /test')
+          expect(span.type).to eq('web')
+        end
+      end
+
+      it 'sets tags for endpoint discovery' do
+        aggregate_failures('http tags') do
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.url')).to eq('https://api.example.com/test')
+          expect(span.get_tag('http.route')).to eq('/test')
+          expect(span.get_tag('http.useragent')).to eq('TestAgent/2.0')
+          expect(span.get_tag('span.kind')).to eq('server')
+        end
+      end
+
+      it 'sets tags for API Gateway resource correlation' do
+        aggregate_failures('gateway tags') do
+          expect(span.get_tag('apiid')).to eq('xyz789')
+          expect(span.get_tag('stage')).to eq('prod')
+          expect(span.get_tag('dd_resource_key')).to eq(
+            'arn:aws:apigateway:us-east-1::/apis/xyz789/stages/prod'
+          )
+        end
+      end
+
+      context 'when routeKey has no method prefix' do
+        let(:event) do
+          {
+            'rawPath' => '/test',
+            'routeKey' => '$default',
+            'requestContext' => {
+              'stage' => 'prod',
+              'domainName' => 'api.example.com',
+              'apiId' => 'xyz789',
+              'timeEpoch' => 1_700_000_000_000,
+              'http' => {'method' => 'GET'},
+            },
+          }
+        end
+
+        it 'uses routeKey as-is for route' do
+          aggregate_failures('route and resource') do
+            expect(span.get_tag('http.route')).to eq('$default')
+            expect(span.resource).to eq('GET $default')
+          end
+        end
+      end
+    end
+
+    context 'when an error occurs' do
+      before { allow(Datadog::Tracing).to receive(:trace).and_raise(StandardError, 'boom') }
+
+      let(:event) do
+        {
+          'httpMethod' => 'GET',
+          'path' => '/test',
+          'requestContext' => {'stage' => 'prod'},
+        }
+      end
+
+      it { expect(span).to be_nil }
+    end
+  end
+end

--- a/test/datadog/lambda/inferred_span/api_gateway_v1.spec.rb
+++ b/test/datadog/lambda/inferred_span/api_gateway_v1.spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/inferred_span/api_gateway_v1'
+require 'datadog/lambda/event_source/api_gateway_v1'
+
+RSpec.describe Datadog::Lambda::InferredSpan::ApiGatewayV1 do
+  subject(:inferred_span) { described_class.new(event_source) }
+
+  let(:event_source) { Datadog::Lambda::EventSource::ApiGatewayV1.new(payload) }
+  let(:payload) do
+    {
+      'httpMethod' => 'GET',
+      'path' => '/users/42',
+      'requestContext' => {
+        'stage' => 'prod',
+        'domainName' => 'api.example.com',
+        'apiId' => 'abc123',
+        'resourcePath' => '/users/{id}',
+        'requestTimeEpoch' => 1_700_000_000_000,
+        'identity' => {'userAgent' => 'TestAgent/1.0'},
+      },
+    }
+  end
+
+  context 'when all fields are present' do
+    it { expect(inferred_span.span_name).to eq('aws.apigateway') }
+    it { expect(inferred_span.method).to eq('GET') }
+    it { expect(inferred_span.path).to eq('/users/42') }
+    it { expect(inferred_span.resource_path).to eq('/users/{id}') }
+    it { expect(inferred_span.domain).to eq('api.example.com') }
+    it { expect(inferred_span.api_id).to eq('abc123') }
+    it { expect(inferred_span.stage).to eq('prod') }
+    it { expect(inferred_span.request_time_ms).to eq(1_700_000_000_000) }
+    it { expect(inferred_span.user_agent).to eq('TestAgent/1.0') }
+    it { expect(inferred_span.arn_path_prefix).to eq('restapis') }
+  end
+
+  context 'when optional fields are missing' do
+    let(:payload) { {'httpMethod' => 'POST', 'requestContext' => {'stage' => 'dev'}} }
+
+    it { expect(inferred_span.path).to eq('/') }
+    it { expect(inferred_span.resource_path).to eq('/') }
+    it { expect(inferred_span.domain).to be_nil }
+    it { expect(inferred_span.api_id).to be_nil }
+    it { expect(inferred_span.stage).to eq('dev') }
+    it { expect(inferred_span.request_time_ms).to be_nil }
+    it { expect(inferred_span.user_agent).to be_nil }
+  end
+end

--- a/test/datadog/lambda/inferred_span/api_gateway_v2.spec.rb
+++ b/test/datadog/lambda/inferred_span/api_gateway_v2.spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/inferred_span/api_gateway_v2'
+require 'datadog/lambda/event_source/api_gateway_v2'
+
+RSpec.describe Datadog::Lambda::InferredSpan::ApiGatewayV2 do
+  subject(:inferred_span) { described_class.new(event_source) }
+
+  let(:event_source) { Datadog::Lambda::EventSource::ApiGatewayV2.new(payload) }
+  let(:payload) do
+    {
+      'rawPath' => '/users/42',
+      'routeKey' => 'GET /users/{id}',
+      'requestContext' => {
+        'stage' => 'prod',
+        'domainName' => 'api.example.com',
+        'apiId' => 'xyz789',
+        'timeEpoch' => 1_700_000_000_000,
+        'http' => {'method' => 'GET', 'userAgent' => 'TestAgent/2.0'},
+      },
+    }
+  end
+
+  context 'when all fields are present' do
+    it { expect(inferred_span.span_name).to eq('aws.httpapi') }
+    it { expect(inferred_span.method).to eq('GET') }
+    it { expect(inferred_span.path).to eq('/users/42') }
+    it { expect(inferred_span.resource_path).to eq('/users/{id}') }
+    it { expect(inferred_span.domain).to eq('api.example.com') }
+    it { expect(inferred_span.api_id).to eq('xyz789') }
+    it { expect(inferred_span.stage).to eq('prod') }
+    it { expect(inferred_span.request_time_ms).to eq(1_700_000_000_000) }
+    it { expect(inferred_span.user_agent).to eq('TestAgent/2.0') }
+    it { expect(inferred_span.arn_path_prefix).to eq('apis') }
+  end
+
+  context 'when routeKey has no method prefix' do
+    let(:payload) do
+      {
+        'rawPath' => '/test',
+        'routeKey' => '$default',
+        'requestContext' => {
+          'stage' => 'prod',
+          'http' => {'method' => 'GET'},
+        },
+      }
+    end
+
+    it { expect(inferred_span.resource_path).to eq('$default') }
+  end
+
+  context 'when optional fields are missing' do
+    let(:payload) { {'routeKey' => 'POST /data', 'requestContext' => {'stage' => 'dev'}} }
+
+    it { expect(inferred_span.path).to eq('/') }
+    it { expect(inferred_span.resource_path).to eq('/data') }
+    it { expect(inferred_span.domain).to be_nil }
+    it { expect(inferred_span.api_id).to be_nil }
+    it { expect(inferred_span.stage).to eq('dev') }
+    it { expect(inferred_span.request_time_ms).to be_nil }
+    it { expect(inferred_span.user_agent).to be_nil }
+    it { expect(inferred_span.method).to be_nil }
+  end
+end

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
-
 require 'datadog/lambda/trace/context'
 require 'datadog/lambda/trace/constants'
 require 'datadog/lambda/trace/listener'
@@ -204,12 +202,15 @@ describe Datadog::Trace do
       res = listener.send(:get_option_tags, request_context: ctx, cold_start: false)
       expect(res).to eq(
         tags: {
+          'span.kind' => 'server',
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:hello-dog-ruby-dev-hello',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: "hello-dog-ruby-dev-helloRuby#{RUBY_VERSION[0, 3].tr('.', '')}",
           functionname: "hello-dog-ruby-dev-helloRuby#{RUBY_VERSION[0, 3].tr('.', '')}".downcase,
-          function_version: '$LATEST'
+          function_version: '$LATEST',
+          datadog_lambda: '3.27.0',
+          dd_trace: '2.29.0'
         }
       )
     end
@@ -227,12 +228,15 @@ describe Datadog::Trace do
       res = listener.send(:get_option_tags, request_context: ctx, cold_start: false)
       expect(res).to eq(
         tags: {
+          'span.kind' => 'server',
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:ruby-test',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: 'Ruby-test',
           functionname: 'ruby-test',
-          function_version: '1'
+          function_version: '1',
+          datadog_lambda: '3.27.0',
+          dd_trace: '2.29.0'
         }
       )
     end
@@ -250,16 +254,34 @@ describe Datadog::Trace do
       res = listener.send(:get_option_tags, request_context: ctx, cold_start: false)
       expect(res).to eq(
         tags: {
+          'span.kind' => 'server',
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:ruby-test',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: 'Ruby-test',
           functionname: 'ruby-test',
-          function_version: 'my-alias'
+          function_version: 'my-alias',
+          datadog_lambda: '3.27.0',
+          dd_trace: '2.29.0'
         }
       )
     end
   end
-end
 
-# rubocop:enable Metrics/BlockLength
+  context 'when datadog gem is unavailable' do
+    before { allow(Datadog::Utils).to receive(:dd_trace_version).and_return(nil) }
+
+    let(:result) { listener.send(:get_option_tags, request_context: ctx, cold_start: false) }
+    let(:ctx) { LambdaContext.new }
+    let(:listener) do
+      Datadog::Trace::Listener.new(
+        handler_name: 'foo', function_name: 'bar',
+        patch_http: true, merge_xray_traces: false
+      )
+    end
+
+    it 'excludes dd_trace from option tags' do
+      expect(result[:tags]).not_to have_key(:dd_trace)
+    end
+  end
+end

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -191,6 +191,8 @@ describe Datadog::Trace do
   end
 
   context 'get_option_tags_for_function' do
+    before { allow(Datadog::Utils).to receive(:dd_trace_version).and_return('2.29.0') }
+
     ctx = LambdaContext.new
     listener = Datadog::Trace::Listener.new(
       handler_name: 'foo',
@@ -217,6 +219,8 @@ describe Datadog::Trace do
   end
 
   context 'get_option_tags_for_function_with_version' do
+    before { allow(Datadog::Utils).to receive(:dd_trace_version).and_return('2.29.0') }
+
     ctx = LambdaContextVersion.new
     listener = Datadog::Trace::Listener.new(
       handler_name: 'foo',
@@ -243,6 +247,8 @@ describe Datadog::Trace do
   end
 
   context 'get_option_tags_for_function_with_alias' do
+    before { allow(Datadog::Utils).to receive(:dd_trace_version).and_return('2.29.0') }
+
     ctx = LambdaContextAlias.new
     listener = Datadog::Trace::Listener.new(
       handler_name: 'foo',

--- a/test/datadog/lambda/trace/listener.spec.rb
+++ b/test/datadog/lambda/trace/listener.spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/trace/listener'
+require_relative '../../lambdacontext'
+
+RSpec.describe Datadog::Trace::Listener do
+  describe '#on_end' do
+    before do
+      allow(Datadog::Utils).to receive(:send_start_invocation_request).and_return(nil)
+      allow(Datadog::Utils).to receive(:send_end_invocation_request)
+      allow(Datadog::Tracing).to receive(:trace).and_return(span)
+    end
+
+    let(:listener) do
+      described_class.new(
+        handler_name: 'handler', function_name: 'my-function',
+        patch_http: false, merge_xray_traces: false
+      )
+    end
+    let(:request_context) { LambdaContext.new }
+    let(:span) { instance_double(Datadog::Tracing::SpanOperation, id: 123, finish: nil) }
+
+    context 'when inferred span exists' do
+      before do
+        allow(Datadog::Lambda::InferredSpan).to receive(:try_create).and_return(inferred_span)
+        listener.on_start(event: {}, request_context: request_context, cold_start: false)
+      end
+
+      let(:inferred_span) { instance_double(Datadog::Tracing::SpanOperation, finish: nil) }
+
+      it 'finishes lambda span before inferred span' do
+        order = []
+        allow(span).to receive(:finish) { order << :lambda }
+        allow(inferred_span).to receive(:finish) { order << :inferred }
+
+        listener.on_end(response: nil, request_context: request_context)
+        expect(order).to eq(%i[lambda inferred])
+      end
+    end
+  end
+end

--- a/test/datadog/lambda/trace/listener.spec.rb
+++ b/test/datadog/lambda/trace/listener.spec.rb
@@ -4,6 +4,77 @@ require 'datadog/lambda/trace/listener'
 require_relative '../../lambdacontext'
 
 RSpec.describe Datadog::Trace::Listener do
+  describe '#on_start' do
+    before do
+      allow(Datadog::Utils).to receive(:send_start_invocation_request).and_return(nil)
+      allow(Datadog::Tracing).to receive(:trace).and_return(
+        instance_double(Datadog::Tracing::SpanOperation)
+      )
+    end
+
+    let(:request_context) { LambdaContext.new }
+    let(:on_start) do
+      listener.on_start(event: {}, request_context: request_context, cold_start: false)
+    end
+
+    context 'when DD_SERVICE is configured' do
+      before { allow(Datadog.configuration).to receive(:service).and_return('my-custom-service') }
+
+      let(:listener) do
+        described_class.new(
+          handler_name: 'handler', function_name: 'my-function',
+          patch_http: false, merge_xray_traces: false
+        )
+      end
+
+      it 'uses DD_SERVICE for service and function name for resource' do
+        on_start
+        expect(Datadog::Tracing).to have_received(:trace).with(
+          'aws.lambda',
+          hash_including(service: 'my-custom-service', resource: 'my-function')
+        )
+      end
+    end
+
+    context 'when DD_SERVICE is not configured' do
+      before { allow(Datadog.configuration).to receive(:service).and_return(nil) }
+
+      let(:listener) do
+        described_class.new(
+          handler_name: 'handler', function_name: 'my-function',
+          patch_http: false, merge_xray_traces: false
+        )
+      end
+
+      it 'uses function name for both service and resource' do
+        on_start
+        expect(Datadog::Tracing).to have_received(:trace).with(
+          'aws.lambda',
+          hash_including(service: 'my-function', resource: 'my-function')
+        )
+      end
+    end
+
+    context 'when function_name is nil' do
+      before { allow(Datadog.configuration).to receive(:service).and_return(nil) }
+
+      let(:listener) do
+        described_class.new(
+          handler_name: 'handler', function_name: nil,
+          patch_http: false, merge_xray_traces: false
+        )
+      end
+
+      it 'falls back to aws.lambda for both service and resource' do
+        on_start
+        expect(Datadog::Tracing).to have_received(:trace).with(
+          'aws.lambda',
+          hash_including(service: 'aws.lambda', resource: 'aws.lambda')
+        )
+      end
+    end
+  end
+
   describe '#on_end' do
     before do
       allow(Datadog::Utils).to receive(:send_start_invocation_request).and_return(nil)

--- a/test/datadog/lambda/trace/listener.spec.rb
+++ b/test/datadog/lambda/trace/listener.spec.rb
@@ -89,7 +89,25 @@ RSpec.describe Datadog::Trace::Listener do
       )
     end
     let(:request_context) { LambdaContext.new }
-    let(:span) { instance_double(Datadog::Tracing::SpanOperation, id: 123, finish: nil) }
+    let(:span) { instance_double(Datadog::Tracing::SpanOperation, id: 123, set_tag: nil, finish: nil) }
+
+    context 'when response contains statusCode' do
+      before { listener.on_start(event: {}, request_context: request_context, cold_start: false) }
+
+      it 'sets http.status_code on the lambda span' do
+        listener.on_end(response: { statusCode: 200 }, request_context: request_context)
+        expect(span).to have_received(:set_tag).with('http.status_code', 200)
+      end
+    end
+
+    context 'when response is not a Hash' do
+      before { listener.on_start(event: {}, request_context: request_context, cold_start: false) }
+
+      it 'does not set http.status_code' do
+        listener.on_end(response: nil, request_context: request_context)
+        expect(span).not_to have_received(:set_tag)
+      end
+    end
 
     context 'when inferred span exists' do
       before do
@@ -97,7 +115,15 @@ RSpec.describe Datadog::Trace::Listener do
         listener.on_start(event: {}, request_context: request_context, cold_start: false)
       end
 
-      let(:inferred_span) { instance_double(Datadog::Tracing::SpanOperation, finish: nil) }
+      let(:inferred_span) { instance_double(Datadog::Tracing::SpanOperation, finish: nil, set_tag: nil) }
+
+      it 'sets http.status_code on both spans' do
+        listener.on_end(response: { statusCode: 200 }, request_context: request_context)
+        aggregate_failures 'status code on both spans' do
+          expect(span).to have_received(:set_tag).with('http.status_code', 200)
+          expect(inferred_span).to have_received(:set_tag).with('http.status_code', 200)
+        end
+      end
 
       it 'finishes lambda span before inferred span' do
         order = []

--- a/test/datadog/lambda/utils/version.spec.rb
+++ b/test/datadog/lambda/utils/version.spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'datadog/lambda/utils/version'
+
+RSpec.describe Datadog::Utils, '.dd_trace_version' do
+  subject(:version) { described_class.dd_trace_version }
+
+  context 'when datadog gem is loaded' do
+    it { expect(version).to match(/\A\d+\.\d+\.\d+/) }
+  end
+
+  context 'when datadog gem is not available' do
+    before do
+      allow(Gem).to receive(:loaded_specs).and_raise(StandardError)
+      allow(Datadog::Utils.logger).to receive(:debug)
+    end
+
+    it { expect(version).to be_nil }
+
+    it 'logs a debug message' do
+      version
+      expect(Datadog::Utils.logger).to have_received(:debug).with('datadog unavailable')
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is **Part 1** of the [Endpoint Discovery & Correlation from Inferred Spans](https://docs.google.com/document/d/1lH9RCZLR6SyJmPAIRYBpv4sKRy54kUAWOMPuOAOpS2Q/edit?pli=1&tab=t.0#heading=h.4kapbym3f1x2) RFC. Part 2 (AppSec integration) will follow in a separate PR to keep review scope manageable.

Full combined version of both parts: https://github.com/DataDog/datadog-lambda-rb/pull/136

## What this PR does

Introduces **inferred spans** for API Gateway v1 (REST) and v2 (HTTP API) events. An inferred span represents the upstream API Gateway service and becomes the parent of the `aws.lambda` span, enabling endpoint discovery and resource correlation in Datadog.

The implementation adds:
- `EventSource` — detection and parsing of Lambda event payloads into a uniform interface
- `InferredSpan` — span factory that creates correctly-tagged parent spans for supported event sources

## Fixes

The `aws.lambda` span previously used hardcoded `service: 'aws.lambda'` and `resource: 'dd-tracer-serverless-span'`, which made traces hard to find and didn't match other language tracers. This PR changes it to use `DD_SERVICE` (or function name) for service and function name for resource, consistent with Python and Go.

## Missing tags catch-up

Aligns Ruby with Python/Go/Java by adding the following tags to the `aws.lambda` span:

- `span.kind: server`
- `datadog_lambda` (gem version)
- `dd_trace` (tracer version)
- `http.method`, `http.url`, `http.useragent` (when API Gateway event detected)
- `http.status_code` on both `aws.lambda` and inferred spans (extracted from handler response)

### Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

## Test plan

- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rake test` — 163 examples, 0 failures
- [x] Verified zero AppSec references in the diff