### PR TITLE
bump minor version to 3.28.0

### DIFF
--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 3
-      MINOR = 27
+      MINOR = 28
       PATCH = 0
       PRE = nil
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-rb/blob/main/CONTRIBUTING.md) if you have not yet done so. --->

### What does this PR do?

Release bump from `v3.27.0` to `v3.28.0`. This release packages up the Ruby 4.0 work merged in #148.

Notable changes since `v3.27.0`:

- **feat: support Ruby 4.0** (#148) — adds `Datadog-Ruby4-0` and `Datadog-Ruby4-0-ARM` published layers; bumps bundled `datadog` gem from `2.12` to `2.30` (required for Ruby 4.0 install support — affects 3.2 / 3.3 / 3.4 layers too); bumps `rake` dev dependency from `~> 12.3` to `~> 13.0` (Ruby 4.0 removed `ostruct` from default gems).

### Motivation

[APMSVLS-512](https://datadoghq.atlassian.net/browse/APMSVLS-512). Cuts a release so the `Datadog-Ruby4-0` / `Datadog-Ruby4-0-ARM` layers get published, which in turn unblocks the Ruby 4.0 e2e tests in [serverless-e2e-tests#223](https://github.com/DataDog/serverless-e2e-tests/pull/223).

### Testing Guidelines

Per the [Lambda Layer Ruby runbook](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723578786/Lambda+Layer+Ruby): once this PR's gitlab pipeline finishes its `build layer` / `check layer size` / `unit test` / `integration test` jobs, the **`sandbox publish` jobs are manual** — clicking those will publish test layers to the `serverless-sandbox` AWS account (`425362996713`) for verification.

Plan:

1. Wait for build + integration tests to pass.
2. Manually trigger the relevant `publish layer sandbox` jobs to get test layer ARNs.
3. Run the full ruby34 + ruby40 e2e suite locally from `serverless-e2e-tests` using those test ARNs (via `DD_RUBY_34_ARN` / `DD_RUBY_40_ARN` env vars) before merging.
4. Only after step 3 is green: merge, tag `v3.28.0`, push tag, click the prod `signing` + `publish` jobs per runbook.

**This PR is intentionally a draft** until step 3 is green.

### Additional Notes

Diff is a single-line minor bump of `MINOR = 27` → `MINOR = 28` in `lib/datadog/lambda/version.rb`. No code or test changes — `47057fb` (the merge of #148) is already on `main`.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog

[APMSVLS-512]: https://datadoghq.atlassian.net/browse/APMSVLS-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ