### PR TITLE
Compile FFI from source using AWS Lambda image

### DIFF
--- a/.gitlab/scripts/build_layer.sh
+++ b/.gitlab/scripts/build_layer.sh
@@ -41,9 +41,12 @@ function docker_build_zip {
 
     # Install datadog ruby in a docker container to avoid the mess from switching
     # between different ruby runtimes.
+    #
+    # NOTE: using the Lambda base image so native extensions (FFI, libddwaf)
+    #       compile against the same libffi available at runtime on Lambda.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-ruby-${arch}:$1 . --no-cache \
-        --build-arg "image=ruby:${1}" \
+        --build-arg "image=public.ecr.aws/lambda/ruby:${1}" \
         --build-arg "runtime=${1}.0" \
         --build-arg "git_ref=${ref}" \
         --platform linux/${arch} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,40 @@ RUN echo "git_ref: $git_ref"
 # Install dev dependencies
 COPY . /var/task/datadog-lambda-rb
 WORKDIR /var/task/datadog-lambda-rb
-RUN apt-get update
-RUN apt-get install -y gcc zip binutils
+# NOTE: AL2 (Ruby 3.2) uses yum, AL2023 (Ruby 3.3+) uses dnf
+RUN PKG=$(command -v dnf || command -v yum) && \
+    $PKG install -y gcc gcc-c++ make zip binutils libffi-devel
 
 # Install this gem
 RUN gem build datadog-lambda
 
 # Install ddtrace gem
-RUN gem install datadog-lambda --install-dir "/opt/ruby/gems/$runtime"
+RUN MAKEFLAGS="-j$(nproc)" \
+    gem install datadog-lambda --install-dir "/opt/ruby/gems/$runtime" --no-document
 RUN set -eux; \
     if [ -z "${git_ref:-}" ]; then \
         # NOTE: datadog gem must be >= 2.24 to install on Ruby 4.0.x.
-        gem install datadog -v 2.30 --install-dir "/opt/ruby/gems/$runtime"; \
+        MAKEFLAGS="-j$(nproc)" \
+        gem install datadog -v 2.30 --install-dir "/opt/ruby/gems/$runtime" --no-document; \
     else \
         echo "building tracer from ref: $git_ref\n"; \
         git clone https://github.com/DataDog/dd-trace-rb.git --depth 1 --single-branch -b $git_ref /tmp/dd-trace-rb; \
         cd /tmp/dd-trace-rb; \
         gem build datadog.gemspec; \
-        gem install ./datadog-*.gem --install-dir "/opt/ruby/gems/$runtime"; \
+        MAKEFLAGS="-j$(nproc)" \
+        gem install ./datadog-*.gem --install-dir "/opt/ruby/gems/$runtime" --no-document; \
     fi
+
+# Recompile FFI from source — precompiled binaries ship ABI-specific ffi_c.so
+# for Ruby 3.3/3.4 only. Ruby 3.2 ABI is missing, causing LoadError at boot
+# when AppSec loads libddwaf → ffi → ffi_c.
+#
+# NOTE: runs after datadog gem as a defensive measure — force-replaces whatever
+#       transitive FFI variant was pulled, regardless of version resolution.
+RUN gem uninstall ffi --all --ignore-dependencies --executables --force \
+        --install-dir "/opt/ruby/gems/$runtime" || true
+RUN MAKEFLAGS="-j$(nproc)" \
+    gem install ffi --platform ruby --install-dir "/opt/ruby/gems/$runtime" --no-document
 
 WORKDIR /opt
 # Remove native extension debase-ruby_core_source (25MB) runtimes below Ruby 2.6

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -37,9 +37,12 @@ function docker_build_zip {
 
     # Install datadog ruby in a docker container to avoid the mess from switching
     # between different ruby runtimes.
+    #
+    # NOTE: using the Lambda base image so native extensions (FFI, libddwaf)
+    #       compile against the same libffi available at runtime on Lambda.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-ruby-${arch}:$1 . --no-cache \
-        --build-arg "image=ruby:${1}" \
+        --build-arg "image=public.ecr.aws/lambda/ruby:${1}" \
         --build-arg "runtime=${1}.0" \
         --build-arg "git_ref=${ref}" \
         --platform linux/${arch} \


### PR DESCRIPTION
### What does this PR do?

Switch layer build from `ruby:X.Y` (Debian) to `public.ecr.aws/lambda/ruby:X.Y` so native extensions compile against Lambda's actual `glibc`/`libffi`.

After `datadog` gem install, uninstall precompiled FFI (missing Ruby 3.2 ABI) and reinstall from source. Fixes cold-start LoadError on `ffi_c` with `DD_APPSEC_ENABLED=true` on Ruby 3.2.

Also adds `MAKEFLAGS` parallelization and `--no-document` to gem installs.

### Motivation

This should help with datadog gem upgrade in the future.

### Testing Guidelines

Locally + CI

### Additional Notes

*Build time improvement*

| Step | Before | After |
|------|--------|-------|
| `gem install datadog-lambda` | ~2 min | ~2 min |
| `gem install datadog` | ~6 min | ~5 min |
| `gem install ffi` | ~3 min | ~2 min |
| **Total** | **~11 min** | **~9 min** |

This PR is a compilation of https://github.com/DataDog/datadog-lambda-rb/pull/144 and https://github.com/DataDog/datadog-lambda-rb/pull/152

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
