### PR TITLE
bump minor version to 3.29.0

### DIFF
--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 3
-      MINOR = 28
+      MINOR = 29
       PATCH = 0
       PRE = nil
 


### PR DESCRIPTION
### What does this PR do?

Release bump from `v3.28.0` to `v3.29.0`. This release packages up two changes merged since `v3.28.0`:

- **[APPSEC-61865] Add AppSec setup for AWS Lambda** (#144) — adds the AppSec request/response normalization + gateway push path for API Gateway events, instruments `aws_lambda` AppSec, and pins `dd-trace-rb` to `2.34` (which ships the matching `Contrib::AwsLambda` watcher / `WAFAddresses` consumer).
- **fix: compile FFI from source using the AWS Lambda image** (#153) — switches the layer build from `ruby:X.Y` (Debian) to `public.ecr.aws/lambda/ruby:X.Y` so native extensions compile against Lambda's actual glibc / libffi, then reinstalls `ffi` from source. Fixes the cold-start `LoadError: cannot load such file -- ffi_c` crash on Ruby 3.2 when `DD_APPSEC_ENABLED=true`.

### Motivation

Cuts a release so the AppSec-enabled, FFI-fixed `Datadog-Ruby3-2` / `Datadog-Ruby3-3` / `Datadog-Ruby3-4` / `Datadog-Ruby4-0` (and `-ARM` variants) layers get published. This unblocks the `(ruby32, appsec_tracer)` scenarios currently xfailed in [`serverless-e2e-tests`](https://github.com/DataDog/serverless-e2e-tests) — see validation PR [#226](https://github.com/DataDog/serverless-e2e-tests/pull/226).

### Testing Guidelines

Per the [Lambda Layer Ruby runbook](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723578786/Lambda+Layer+Ruby): once this PR's gitlab pipeline finishes its `build layer` / `check layer size` / `unit test` / `integration test` jobs, the `publish layer sandbox` jobs are **manual**.

Plan:

1. Wait for build + integration tests to pass.
2. Tag `v3.29.0`, push tag, wait for the e2e tests to pass.
3. Validate the AppSec + FFI fix end-to-end via serverless-e2e-tests#226 (un-xfails `ruby32` + `appsec_tracer`).
4. Click the prod `signing` + `publish` jobs per runbook; publish to GovCloud; publish the gem.

### Additional Notes

Diff is a single-line minor bump of `MINOR = 28` → `MINOR = 29` in `lib/datadog/lambda/version.rb`. Branch is based on current `main` (`898e93e`), so the tag cut from this release will include both #144 and #153.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog

[APPSEC-61865]: https://datadoghq.atlassian.net/browse/APPSEC-61865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ