### PR TITLE
Fix async-metrics integration-test flake (blank log line)

### DIFF
--- a/integration_tests/snapshots/logs/appsec-request_ruby32.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby32.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/appsec-request_ruby33.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby33.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/appsec-request_ruby34.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby34.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/appsec-request_ruby40.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby40.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby32.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby33.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby33.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby34.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby34.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_ruby40.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby40.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby32.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby32.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby33.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby33.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby34.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby34.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/http-requests_ruby40.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby40.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby32.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby32.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby33.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby33.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby34.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby34.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/process-input-traced_ruby40.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby40.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby32.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby33.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby33.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby34.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby34.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/sync-metrics_ruby40.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby40.log
@@ -1,4 +1,3 @@
-
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -233,6 +233,9 @@ for handler_name in "${LAMBDA_HANDLERS[@]}"; do
                 perl -p -e 's/(D, \[)( )?[a-zA-Z0-9\.\:\s\-\#]+/\1XXXX/g' |
                 # Filter out INIT runtime logs
                 perl -p -e "s/INIT_START.*//g" |
+                # NOTE: Async metric flush emits a non-deterministic empty log line.
+                #       We drop blank lines so the comparison doesn't flake on it
+                sed '/^$/d' |
                 sort
         )
 


### PR DESCRIPTION
The async metric flush emits a non-deterministic empty log line that sporadically fails the log snapshot comparison. Strip blank lines in the normalization pipeline and re-baseline the snapshots.