### PR TITLE
Bump datadog dependency floor to 2.40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
     if [ -z "${git_ref:-}" ]; then \
         # NOTE: datadog gem must be >= 2.24 to install on Ruby 4.0.x.
         MAKEFLAGS="-j$(nproc)" \
-        gem install datadog -v 2.39 --install-dir "/opt/ruby/gems/$runtime" --no-document; \
+        gem install datadog -v 2.40 --install-dir "/opt/ruby/gems/$runtime" --no-document; \
     else \
         echo "building tracer from ref: $git_ref\n"; \
         git clone https://github.com/DataDog/dd-trace-rb.git --depth 1 --single-branch -b $git_ref /tmp/dd-trace-rb; \

--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   # native modules that are difficult to package for lambda.
   #
   # NOTE: 2.24 is the floor for Ruby 4.0 install support
-  spec.add_development_dependency 'datadog', '~> 2.39'
+  spec.add_development_dependency 'datadog', '~> 2.40'
 
   # Development dependencies
   # NOTE: rake >= 13 is required for Ruby 4.0 support — rake 12.x pulls in

--- a/integration_tests/snapshots/logs/appsec-request_ruby32.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby32.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/appsec-request_ruby33.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby33.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/appsec-request_ruby34.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby34.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/appsec-request_ruby40.log
+++ b/integration_tests/snapshots/logs/appsec-request_ruby40.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/async-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby32.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/async-metrics_ruby33.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby33.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/async-metrics_ruby34.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby34.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/async-metrics_ruby40.log
+++ b/integration_tests/snapshots/logs/async-metrics_ruby40.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/http-requests_ruby32.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby32.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/http-requests_ruby33.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby33.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/http-requests_ruby34.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby34.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/http-requests_ruby40.log
+++ b/integration_tests/snapshots/logs/http-requests_ruby40.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby32.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby32.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby33.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby33.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby34.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby34.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/process-input-traced_ruby40.log
+++ b/integration_tests/snapshots/logs/process-input-traced_ruby40.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 START
 START

--- a/integration_tests/snapshots/logs/sync-metrics_ruby32.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby32.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.2.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.2.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/sync-metrics_ruby33.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby33.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.3.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.3.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/sync-metrics_ruby34.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby34.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"3.4.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-3.4.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request

--- a/integration_tests/snapshots/logs/sync-metrics_ruby40.log
+++ b/integration_tests/snapshots/logs/sync-metrics_ruby40.log
@@ -3,7 +3,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
 END Duration: XXXX ms Memory Used: XXXX MB
-I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.39.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
+I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - CORE - {"date":"XXXX","os_name":"XXXX","version":"2.40.0","lang":"ruby","lang_version":"4.0.X","env":null,"service":"index","dd_version":null,"debug":false,"tags":"_dd.origin:lambda","runtime_metrics_enabled":false,"vm":"ruby-4.0.X","health_metrics_enabled":false,"profiling_enabled":false,"dynamic_instrumentation_enabled":false}
 I, [XXXX]  INFO XXXX[datadog] DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":null,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":"aws@","partial_flushing_enabled":false}
 Processed APIGateway request
 Processed APIGateway request


### PR DESCRIPTION
Raises the `datadog` development dependency floor to `~> 2.40` and updates the integration-test log snapshots to the 2.40.0 tracer CORE version line.