### PR TITLE
bump minor version to 3.30.0

### DIFF
--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 3
-      MINOR = 29
+      MINOR = 30
       PATCH = 0
       PRE = nil
 


### PR DESCRIPTION
Release bump for datadog-lambda-rb 3.30.0.

Changes since 3.29.0:
- Bump datadog tracer to 2.40 (#164)
- [APPSEC-68196] Cover gaps for AppSec products in SLS (#162)
- Drop blank lines from integration-test logs to fix async-metrics flake (#163)
- Add ap-east-2 and ap-southeast-6 to supported regions (#161)
- Move publish rubygems to Github Actions trusted publisher workflow (#157)
- update snapshots (#159)

E2E tests (Release Candidate) have already passed.

[APPSEC-68196]: https://datadoghq.atlassian.net/browse/APPSEC-68196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ