### PR TITLE
Stop duplicate CI runs on PR branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: build
 
-on: [push, pull_request]
+on: # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`on: [push, pull_request]` fires **both** events for the same commit when a branch has an open PR, so every `build` job runs twice. This is visible on recent PRs (e.g. #164) where each job — `lint`, `unit-test (3.2)`, `integration-test (4.0)`, … — appears under two run IDs. Doubles CI wall-time and AWS sandbox usage per PR.

## Fix

Restrict `push` to `main`:

```yaml
on:
  pull_request:
  push:
    branches: [main]
```

- **PR branches** → only `pull_request` fires → one run per commit (no duplicate).
- **Merges to `main`** → `push` fires → still verified.

## Why not `cancel-in-progress` on all branches?

The alternative — keep `push` on all branches and rely on a `concurrency` block with `cancel-in-progress: true` to dedup — leaves the cancelled run reporting `cancelled` (not `success`). Per [GitHub's required-checks docs](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks), only `success`/`skipped`/`neutral` satisfy a required check. This repo has a custom merge gate (`devflow/mergegate` + `DDCI Status` + `dd-gitlab/*`), and introducing `cancelled` check states into a gate we don't control is risky. Restricting `push` to `main` means the duplicate never fires in the first place — no cancellation race, no ambiguous check state.

References: [Adam Johnson](https://adamj.eu/tech/2025/05/14/github-actions-avoid-simple-on), [runs-on.com concurrency guide](https://runs-on.com/github-actions/concurrency).

## Trade-off

Pushes to a feature branch with **no open PR** no longer get CI — you get CI once the PR is opened. (This matches the behavior of most of Datadog's other serverless repos.)

## Other workflows

Unchanged:
- `check-size.yml` → `pull_request` only
- `publish.yml` → `workflow_dispatch` only
- `codeql-analysis.yml` → standalone